### PR TITLE
Roll back datapipes to before major changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch[cpu]>=2.0
 PVNet-summation>=0.0.7
 pvnet>=2.1.29
 ocf_datapipes>=1.2.44
-nowcasting_datamodel>=1.5.10
+ocf_datapipes==1.2.48
 fsspec[s3]
 xarray
 zarr


### PR DESCRIPTION
# Pull Request

## Description

Model has been behaving strangely since most recent build. Roll back `ocf_datapipes` to before major changes in that repo. At least this will rule-out whether the decreased model performance comes from that.
