### PR TITLE
Update summation model to reduce wobbles

### DIFF
--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -72,7 +72,7 @@ default_model_version = "96ac8c67fa8663844ddcfa82aece51ef94f34453"
 # Huggingfacehub model repo and commit for PVNet summation (GSP sum to national model)
 # If summation_model_name is set to None, a simple sum is computed instead
 default_summation_model_name = "openclimatefix/pvnet_v2_summation"
-default_summation_model_version = "4a145d74c725ffc72f482025d3418659a6869c94"
+default_summation_model_version = "ead56528a7ac5681a1d4c9db40dabd2d07c7a55f"
 
 model_name_ocf_db = "pvnet_v2"
 use_adjuster = os.getenv("USE_ADJUSTER", "True").lower() == "true"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch[cpu]>=2.0
-PVNet-summation>=0.0.7
+PVNet-summation>=0.0.8
 pvnet>=2.1.29
 ocf_datapipes>=1.2.44
 nowcasting_datamodel>=1.5.10


### PR DESCRIPTION
# Pull Request

## Description

This updates the summation model used.

The current summation model is a bit noisy. In our forecasts there are some high frequency perturbations from a smooth curve which I do not believe are indicative of model skill, but more the model being overly sensitive to the inputs. Although the accuracy of the model is good, I think it makes us look bad from a user's perspective - can we trust an accurate but wobbly line? These high frequency deviations would also likely make our forecasts worse as measured by ramp-rate. 

This new model is trained with more effective regularisation (due to rescaling the inputs), and is trained for longer using a slower changing learning rate. This results in smoother forecasts, and a very modest improvement in validation scores.

Both the new and old model were trained and validated on the exact same batches, so their validation results can be directly compared. Validation results, and the wandb training logs for the two models are shown below.

| model   | Validation NMAE | Validation Quantile Loss | wandb training log |
| ------- | ----------------- | ----------------------- | ------------------- |
| old        |               0.01448  |                        0.009512 | https://wandb.ai/openclimatefix/pvnet_summation/runs/zda9wo7u |
| new      |                0.01431  |                       0.009384 | https://wandb.ai/openclimatefix/pvnet_summation/runs/xuvy4ld8 |

