### PR TITLE
add optional sum-of-GSP saving

### DIFF
--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -549,7 +549,7 @@ def app(
                 session=session,
                 update_national=True,
                 update_gsp=False,
-                apply_adjuster=apply_adjuster,
+                apply_adjuster=False,
             )
             
 

--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -219,6 +219,8 @@ def app(
 
     logger.info(f"Using `pvnet` library version: {pvnet.__version__}")
     logger.info(f"Using {num_workers} workers")
+    logger.info(f"Using adjduster: {use_adjuster}")
+    logger.info(f"Saving GSP sum: {save_gsp_sum}")
 
     # Allow environment overwrite of model
     model_name = os.getenv("APP_MODEL", default=default_model_name)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,3 @@
-from pvnet_app.app import app
 import tempfile
 import zarr
 import os
@@ -39,19 +38,21 @@ def test_app(db_session, nwp_data, sat_data, gsp_yields_and_systems, me_latest):
         os.environ["SAVE_GSP_SUM"] = "True"
 
         # Run prediction
+        # This import needs to come after the environ vars have been set
+        from pvnet_app.app import app
         app(gsp_ids=list(range(1, 318)))
 
     # Check forecasts have been made
-    # (317 GSPs + 1 National) = 318 forecasts
+    # (317 GSPs + 1 National + GSP-sum) = 319 forecasts
     # Doubled for historic and forecast
     forecasts = db_session.query(ForecastSQL).all()
-    assert len(forecasts) == 318 * 2
+    assert len(forecasts) == 319 * 2
 
     # Check probabilistic added
     assert "90" in forecasts[0].forecast_values[0].properties
     assert "10" in forecasts[0].forecast_values[0].properties
 
     # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 318 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 318 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 318 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,21 +36,22 @@ def test_app(db_session, nwp_data, sat_data, gsp_yields_and_systems, me_latest):
         # Set model version
         os.environ["APP_MODEL_VERSION"] = "96ac8c67fa8663844ddcfa82aece51ef94f34453"
         os.environ["APP_SUMMATION_MODEL_VERSION"] = "4a145d74c725ffc72f482025d3418659a6869c94"
+        os.environ["SAVE_GSP_SUM"] = "True"
 
         # Run prediction
         app(gsp_ids=list(range(1, 318)))
 
     # Check forecasts have been made
-    # (317 GSPs + 1 National) = 318 forecasts
+    # (317 GSPs + 1 National + 1 GSP-sum) = 319 forecasts
     # Doubled for historic and forecast
     forecasts = db_session.query(ForecastSQL).all()
-    assert len(forecasts) == 318 * 2
+    assert len(forecasts) == 319 * 2
 
     # Check probabilistic added
     assert "90" in forecasts[0].forecast_values[0].properties
     assert "10" in forecasts[0].forecast_values[0].properties
 
     # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 318 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 318 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 318 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,16 +42,16 @@ def test_app(db_session, nwp_data, sat_data, gsp_yields_and_systems, me_latest):
         app(gsp_ids=list(range(1, 318)))
 
     # Check forecasts have been made
-    # (317 GSPs + 1 National + 1 GSP-sum) = 319 forecasts
+    # (317 GSPs + 1 National) = 318 forecasts
     # Doubled for historic and forecast
     forecasts = db_session.query(ForecastSQL).all()
-    assert len(forecasts) == 319 * 2
+    assert len(forecasts) == 318 * 2
 
     # Check probabilistic added
     assert "90" in forecasts[0].forecast_values[0].properties
     assert "10" in forecasts[0].forecast_values[0].properties
 
     # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == 318 * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 318 * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 318 * 16


### PR DESCRIPTION
# Pull Request

This saves the sum-of-GSPs under a different model name to the logging. This will allow us to compare the performance of the summation model to the simpler sum-of-GSPs, and help us monitor the summation model's performance more easily.

This is part of #15. 

Includes:
- Optional saving of the sum-of-GSPs using the environmental variable `SAVE_GSP_SUM` (default: False)
- If saved the sum-of-GSPs is saved under the model name `pvnet_gsp_sum`
- Updated tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
