### PR TITLE
add 5/15 sat logic

### DIFF
--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -41,7 +41,9 @@ import pvnet_app
 from pvnet_app.utils import (
     worker_init_fn, populate_data_config_sources, convert_dataarray_to_forecasts, preds_to_dataarray
 )
-from pvnet_app.data import regrid_nwp_data, download_sat_data, download_nwp_data
+from pvnet_app.data import (
+    download_sat_data, download_nwp_data, preprocess_sat_data, regrid_nwp_data,
+)
 
 # ---------------------------------------------------------------------------
 # GLOBAL SETTINGS
@@ -177,6 +179,9 @@ def app(
     logger.info("Downloading satellite data")
     download_sat_data()
 
+    # Process the 5/15 minutely satellite data
+    preprocess_sat_data(t0)
+    
     # Download NWP data
     logger.info("Downloading NWP data")
     download_nwp_data()

--- a/pvnet_app/consts.py
+++ b/pvnet_app/consts.py
@@ -1,3 +1,2 @@
 sat_path = "sat.zarr"
-sat_15_path = "sat_15.zarr"
 nwp_path = "nwp.zarr"

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -55,7 +55,9 @@ def preprocess_sat_data(t0):
         logger.info(f"Latest 15-minute timestamp is {latest_time_15} for t0 time {t0}.")
         
         logger.debug("Resampling 15 minute data to 5 mins")
-        ds_sat_15.resample(time="5T").interpolate("linear").to_zarr(sat_path)
+        #ds_sat_15.resample(time="5T").interpolate("linear").to_zarr(sat_path)
+        ds_sat_15.attrs["source"] = "15-minute"
+        ds_sat_15.to_zarr(sat_path)
                 
         
 def download_nwp_data():

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import xarray as xr
 import xesmf as xe
 import logging

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -3,28 +3,56 @@ import xesmf as xe
 import logging
 import os
 import fsspec
+from datetime import timedelta
+import ocf_blosc2
 
-from pvnet_app.consts import sat_path, sat_15_path, nwp_path
+from pvnet_app.consts import sat_path, nwp_path
 
 logger = logging.getLogger(__name__)
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
+sat_5_path = "sat_5_min.zarr"
+sat_15_path = "sat_15_min.zarr"
+
+
 def download_sat_data():
     """Download the sat data"""
     fs = fsspec.open(os.environ["SATELLITE_ZARR_PATH"]).fs
-    fs.get(os.environ["SATELLITE_ZARR_PATH"], "sat.zarr.zip")
-    os.system(f"rm -r {sat_path}")
-    os.system(f"unzip sat.zarr.zip -d {sat_path}")
+    fs.get(os.environ["SATELLITE_ZARR_PATH"], "sat_5_min.zarr.zip")
+    os.system(f"rm -r {sat_5_path} {sat_15_path} {sat_path}")
+    os.system(f"unzip sat_5_min.zarr.zip -d {sat_5_path}")
     
     # Also download 15-minute satellite if it exists
     sat_latest_15 = os.environ["SATELLITE_ZARR_PATH"].replace("sat.zarr", "sat_15.zarr")
     if fs.exists(sat_latest_15):
         logger.info("Downloading 15-minute satellite data")
-        fs.get(sat_latest_15, "sat_15.zarr")
-        os.system(f"unzip sat_15.zarr.zip -d {sat_15_path}")
+        fs.get(sat_latest_15, sat_15_path)
+        os.system(f"unzip sat_15_min.zarr.zip -d {sat_15_path}")
         
 
+def preprocess_sat_data(t0):
+    """Select and/or combine the 5 and 15-minutely satellite data"""
+    
+    ds_sat_5 = xr.open_zarr(sat_5_path)
+    latest_time_5 = pd.to_datetime(ds_sat_5.time.max().values)
+    sat_delay_5 = t0 - latest_time_5
+    logger.info(f"Latest 5-minute timestamp is {latest_time_5} for t0 time {t0}.")
+    
+    if sat_delay_5 < timedelta(minutes=60):
+        logger.info(f"5-min satellite delay is only {sat_delay_5} - Using 5-minutely data.")
+        os.system(f"mv {sat_5_path} {sat_path}")
+    else:
+        logger.info(f"5-min satellite delay is {sat_delay} - Switching to 15-minutely data.")
+        
+        ds_sat_15 = xr.open_zarr(sat_15_path)
+        latest_time_15 = pd.to_datetime(ds_sat_15.time.max().values)        
+        logger.info(f"Latest 15-minute timestamp is {latest_time_15} for t0 time {t0}.")
+        
+        logger.debug("Resampling 15 minute data to 5 mins")
+        ds_sat_15.resample(time="5T").interpolate("linear").to_zarr(sat_path)
+                
+        
 def download_nwp_data():
     """Download the NWP data"""
     fs = fsspec.open(os.environ["NWP_ZARR_PATH"]).fs

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -19,16 +19,20 @@ sat_15_path = "sat_15_min.zarr"
 
 def download_sat_data():
     """Download the sat data"""
+    
+    # Clean out old files
+    os.system(f"rm -r {sat_path} {sat_5_path} {sat_15_path}")
+    
     fs = fsspec.open(os.environ["SATELLITE_ZARR_PATH"]).fs
     fs.get(os.environ["SATELLITE_ZARR_PATH"], "sat_5_min.zarr.zip")
-    os.system(f"rm -r {sat_5_path} {sat_15_path} {sat_path}")
+    
     os.system(f"unzip sat_5_min.zarr.zip -d {sat_5_path}")
     
     # Also download 15-minute satellite if it exists
-    sat_latest_15 = os.environ["SATELLITE_ZARR_PATH"].replace("sat.zarr", "sat_15.zarr")
-    if fs.exists(sat_latest_15):
+    sat_15_dl_path = os.environ["SATELLITE_ZARR_PATH"].replace("sat.zarr", "sat_15.zarr")
+    if fs.exists(sat_15_dl_path):
         logger.info("Downloading 15-minute satellite data")
-        fs.get(sat_latest_15, sat_15_path)
+        fs.get(sat_15_dl_path, "sat_15_min.zarr.zip")
         os.system(f"unzip sat_15_min.zarr.zip -d {sat_15_path}")
         
 

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -44,7 +44,7 @@ def preprocess_sat_data(t0):
         logger.info(f"5-min satellite delay is only {sat_delay_5} - Using 5-minutely data.")
         os.system(f"mv {sat_5_path} {sat_path}")
     else:
-        logger.info(f"5-min satellite delay is {sat_delay} - Switching to 15-minutely data.")
+        logger.info(f"5-min satellite delay is {sat_delay_5} - Switching to 15-minutely data.")
         
         ds_sat_15 = xr.open_zarr(sat_15_path)
         latest_time_15 = pd.to_datetime(ds_sat_15.time.max().values)        

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch[cpu]>=2.1.1
 PVNet-summation>=0.0.9
-pvnet>=2.4.0
-ocf_datapipes>=2.2.2
+pvnet==2.4.0
+ocf_datapipes==2.2.14
 nowcasting_datamodel>=1.5.22
 fsspec[s3]
 xarray

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,12 +147,11 @@ def sat_5_data():
 
 @pytest.fixture()
 def sat_5_data_delayed(sat_5_data):
-    sat_5_delayed = sat_5_data.copy(deep=True)
-    
     # Set the most recent timestamp to 2 - 2.5 hours ago
     t_most_recent = time_before_present(timedelta(hours=2)).floor(timedelta(minutes=30))
-    offset = sat_5_delayed.time.max().values - t_most_recent
-    sat_5_delayed.time.values[:] = sat_5_delayed.time.values - offset
+    offset = sat_5_data.time.max().values - t_most_recent
+    sat_5_delayed = sat_5_data.copy(deep=True)
+    sat_5_delayed["time"] = sat_5_data.time.values - offset
     return sat_5_delayed
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,7 +118,7 @@ def nwp_data():
 
 
 @pytest.fixture()
-def sat_data():
+def sat_5_data():
     # Load dataset which only contains coordinates, but no data
     ds = xr.open_zarr(
         f"{os.path.dirname(os.path.abspath(__file__))}/test_data/non_hrv_shell.zarr"
@@ -146,25 +146,25 @@ def sat_data():
 
 
 @pytest.fixture()
-def sat_data_delayed(sat_data):
-    sat_delayed = sat_data.copy(deep=True)
+def sat_5_data_delayed(sat_5_data):
+    sat_5_delayed = sat_5_data.copy(deep=True)
     
     # Set the most recent timestamp to 2 - 2.5 hours ago
     t_most_recent = time_before_present(timedelta(hours=2)).floor(timedelta(minutes=30))
-    offset = sat_delayed.time.max().values - t_most_recent
-    sat_delayed.time.values[:] = sat_delayed.time.values - offset
-    return sat_delayed
+    offset = sat_5_delayed.time.max().values - t_most_recent
+    sat_5_delayed.time.values[:] = sat_5_delayed.time.values - offset
+    return sat_5_delayed
 
 
 @pytest.fixture()
-def sat_15_data(sat_data):
+def sat_15_data(sat_5_data):
     freq = timedelta(minutes=15)
     times_15 = pd.date_range(
-        pd.to_datetime(sat_data.time.min().values).ceil(freq),
-        pd.to_datetime(sat_data.time.max().values).floor(freq),
+        pd.to_datetime(sat_5_data.time.min().values).ceil(freq),
+        pd.to_datetime(sat_5_data.time.max().values).floor(freq),
         freq=freq,
     )
-    return sat_data.sel(time=times_15)
+    return sat_5_data.sel(time=times_15)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def engine_url():
         url = postgres.get_connection_url()
         os.environ["DB_URL"] = url
 
-        database_connection = DatabaseConnection(url, echo=True)
+        database_connection = DatabaseConnection(url, echo=False)
 
         engine = database_connection.engine
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def engine_url():
 
 @pytest.fixture()
 def db_connection(engine_url):
-    database_connection = DatabaseConnection(engine_url, echo=True)
+    database_connection = DatabaseConnection(engine_url, echo=False)
 
     engine = database_connection.engine
     # connection = engine.connect()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,7 @@ def test_app(db_session, nwp_data, sat_data, gsp_yields_and_systems, me_latest):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # The app loads sat and NWP data from environment variable
-        # Save out data and set paths
+        # Save out data, and set paths as environmental variables 
         temp_nwp_path = f"{tmpdirname}/nwp.zarr"
         os.environ["NWP_ZARR_PATH"] = temp_nwp_path
         nwp_data.to_zarr(temp_nwp_path)
@@ -31,6 +31,60 @@ def test_app(db_session, nwp_data, sat_data, gsp_yields_and_systems, me_latest):
         os.environ["SATELLITE_ZARR_PATH"] = temp_sat_path
         store = zarr.storage.ZipStore(temp_sat_path, mode="x")
         sat_data.to_zarr(store)
+        store.close()
+
+        # Set model version
+        os.environ["SAVE_GSP_SUM"] = "True"
+
+        # Run prediction
+        # This import needs to come after the environ vars have been set
+        from pvnet_app.app import app
+        app(gsp_ids=list(range(1, 318)), num_workers=2)
+
+    # Check forecasts have been made
+    # (317 GSPs + 1 National + GSP-sum) = 319 forecasts
+    # Doubled for historic and forecast
+    forecasts = db_session.query(ForecastSQL).all()
+    assert len(forecasts) == 319 * 2
+
+    # Check probabilistic added
+    assert "90" in forecasts[0].forecast_values[0].properties
+    assert "10" in forecasts[0].forecast_values[0].properties
+
+    # 318 GSPs * 16 time steps in forecast
+    assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16
+    
+
+def test_app_15(
+    db_session, nwp_data, sat_data_delayed, sat_15_data, gsp_yields_and_systems, me_latest
+):
+    # Environment variable DB_URL is set in engine_url, which is called by db_session
+    # set NWP_ZARR_PATH
+    # save nwp_data to temporary file, and set NWP_ZARR_PATH
+    # SATELLITE_ZARR_PATH
+    # save sat_data to temporary file, and set SATELLITE_ZARR_PATH
+    # GSP data
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # The app loads sat and NWP data from environment variable
+        # Save out data, and set paths as environmental variables 
+        temp_nwp_path = f"{tmpdirname}/nwp.zarr"
+        os.environ["NWP_ZARR_PATH"] = temp_nwp_path
+        nwp_data.to_zarr(temp_nwp_path)
+
+        # In production sat zarr is zipped
+        temp_sat_path = f"{tmpdirname}/sat.zarr.zip"
+        os.environ["SATELLITE_ZARR_PATH"] = temp_sat_path
+        store = zarr.storage.ZipStore(temp_sat_path, mode="x")
+        sat_data_delayed.to_zarr(store)
+        store.close()
+        
+        # Save the 15-minute data too
+        temp_sat_path = f"{tmpdirname}/sat_15.zarr.zip"
+        store = zarr.storage.ZipStore(temp_sat_path, mode="x")
+        sat_15_data.to_zarr(store)
         store.close()
 
         # Set model version

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,7 +11,7 @@ from nowcasting_datamodel.models.forecast import (
 )
 
 
-def _test_app(db_session, nwp_data, sat_5_data, sat_15_data, gsp_yields_and_systems, me_latest):
+def test_app(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest):
     # Environment variable DB_URL is set in engine_url, which is called by db_session
     # set NWP_ZARR_PATH
     # save nwp_data to temporary file, and set NWP_ZARR_PATH
@@ -32,13 +32,6 @@ def _test_app(db_session, nwp_data, sat_5_data, sat_15_data, gsp_yields_and_syst
         store = zarr.storage.ZipStore(temp_sat_path, mode="x")
         sat_5_data.to_zarr(store)
         store.close()
-
-        # Maybe save the 15-minute data too
-        if sat_15_data is not None:
-            temp_sat_path = os.environ["SATELLITE_ZARR_PATH"].replace("sat.zarr", "sat_15.zarr")
-            store = zarr.storage.ZipStore(temp_sat_path, mode="x")
-            sat_15_data.to_zarr(store)
-            store.close()
         
         # Set model version
         os.environ["SAVE_GSP_SUM"] = "True"
@@ -66,28 +59,3 @@ def _test_app(db_session, nwp_data, sat_5_data, sat_15_data, gsp_yields_and_syst
     # Clean up
     db_session.query(ForecastSQL).delete()
     db_session.commit()
-
-
-def test_app_5(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest):
-    
-    _test_app(
-        db_session=db_session, 
-        nwp_data=nwp_data, 
-        sat_5_data=sat_5_data, 
-        sat_15_data=None,
-        gsp_yields_and_systems=gsp_yields_and_systems, 
-        me_latest=me_latest
-    )
-    
-
-def test_app_15(
-    db_session, nwp_data, sat_5_data_delayed, sat_15_data, gsp_yields_and_systems, me_latest
-):
-    _test_app(
-        db_session=db_session, 
-        nwp_data=nwp_data, 
-        sat_5_data=sat_5_data_delayed, 
-        sat_15_data=sat_15_data,
-        gsp_yields_and_systems=gsp_yields_and_systems, 
-        me_latest=me_latest
-    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,7 +55,3 @@ def test_app(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest
     assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
     assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16
-    
-    # Clean up
-    db_session.query(ForecastSQL).delete()
-    db_session.commit()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,19 +47,7 @@ def _test_app(db_session, nwp_data, sat_5_data, sat_15_data, gsp_yields_and_syst
         # This import needs to come after the environ vars have been set
         from pvnet_app.app import app
         app(gsp_ids=list(range(1, 318)), num_workers=2)
-
-
-def test_app(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest):
-    
-    _test_app(
-        db_session=db_session, 
-        nwp_data=nwp_data, 
-        sat_5_data=sat_5_data, 
-        sat_15_data=None,
-        gsp_yields_and_systems=gsp_yields_and_systems, 
-        me_latest=me_latest
-    )
-
+        
     # Check forecasts have been made
     # (317 GSPs + 1 National + GSP-sum) = 319 forecasts
     # Doubled for historic and forecast
@@ -74,6 +62,22 @@ def test_app(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest
     assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
     assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16
+    
+    # Clean up
+    db_session.query(ForecastSQL).delete()
+    db_session.commit()
+
+
+def test_app_5(db_session, nwp_data, sat_5_data, gsp_yields_and_systems, me_latest):
+    
+    _test_app(
+        db_session=db_session, 
+        nwp_data=nwp_data, 
+        sat_5_data=sat_5_data, 
+        sat_15_data=None,
+        gsp_yields_and_systems=gsp_yields_and_systems, 
+        me_latest=me_latest
+    )
     
 
 def test_app_15(
@@ -87,18 +91,3 @@ def test_app_15(
         gsp_yields_and_systems=gsp_yields_and_systems, 
         me_latest=me_latest
     )
-
-    # Check forecasts have been made
-    # (317 GSPs + 1 National + GSP-sum) = 319 forecasts
-    # Doubled for historic and forecast
-    forecasts = db_session.query(ForecastSQL).all()
-    assert len(forecasts) == 319 * 2
-
-    # Check probabilistic added
-    assert "90" in forecasts[0].forecast_values[0].properties
-    assert "10" in forecasts[0].forecast_values[0].properties
-
-    # 318 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 319 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 319 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 319 * 16

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,7 +35,7 @@ def _test_app(db_session, nwp_data, sat_5_data, sat_15_data, gsp_yields_and_syst
 
         # Maybe save the 15-minute data too
         if sat_15_data is not None:
-            temp_sat_path = f"{tmpdirname}/sat_15.zarr.zip"
+            temp_sat_path = os.environ["SATELLITE_ZARR_PATH"].replace("sat.zarr", "sat_15.zarr")
             store = zarr.storage.ZipStore(temp_sat_path, mode="x")
             sat_15_data.to_zarr(store)
             store.close()


### PR DESCRIPTION
# Pull Request

## Description

Currently the logic for switching between 5/15 minutely satellite data is contained inside datapipes. I think its cleaner to have this logic inside this app as it is exclusive to production code. It also stops us having more if/else clauses in the pvnet datapipe for training/production and makes the datapipe more straight forward and maintainable.

Also having it here gives us the opportunity to maybe combine or infill between the 5 and 15-minutely data as well as having more targeted logging.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
