### PR TITLE
nowcasting_datamodel>=1.5.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pydantic
 torch[cpu]==2.1.2
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7
-ocf_datapipes==3.2.4
+ocf_datapipes==3.2.5
 nowcasting_datamodel>=1.5.30
 fsspec[s3]
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic
-torch[cpu]>=2.0.0
+torch[cpu]==2.2.0
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7
 ocf_datapipes>=3.0.1,<3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch[cpu]>=2.0.0
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7
 ocf_datapipes>=3.0.1,<3.1
-nowcasting_datamodel>=1.5.22
+nowcasting_datamodel>=1.5.30
 fsspec[s3]
 xarray
 zarr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic<2.0
+pydantic
 torch[cpu]>=2.0.0
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic
-torch[cpu]==2.2.0
+torch[cpu]==2.1.2
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7
 ocf_datapipes>=3.0.1,<3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic<2.0
+pydantic
 torch[cpu]==2.1.2
 PVNet-summation==0.1.*
 pvnet>=2.6.7,<2.7


### PR DESCRIPTION
# Pull Request

## Description

use nowcasting_datamodel 1.5.30. This restricts the adjust to 20% of the forecast value amount

Fixes #

## How Has This Been Tested?

CI tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
