### PR TITLE
Improved delay #56

### DIFF
--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -52,10 +52,11 @@ def preprocess_sat_data(t0):
         ds_sat_5 = xr.open_zarr(sat_5_path)
         latest_time_5 = pd.to_datetime(ds_sat_5.time.max().values)
         sat_delay_5 = t0 - latest_time_5
+        
         logger.info(f"Latest 5-minute timestamp is {latest_time_5} for t0 time {t0}.")
 
         if sat_delay_5 < timedelta(minutes=60):
-            logger.info(f"5-min satellite delay is only {sat_delay_5} - Using 5-minutely data.")
+            logger.info(f"5-min satellite delay is only {delay_minutes_5} minutes - Using 5-minutely data.")
             os.system(f"mv {sat_5_path} {sat_path}")
         else:
             use_15_minute = True

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -56,6 +56,7 @@ def preprocess_sat_data(t0):
         logger.info(f"Latest 5-minute timestamp is {latest_time_5} for t0 time {t0}.")
 
         if sat_delay_5 < timedelta(minutes=60):
+            delay_minutes_5 = int((sat_delay_5.total_seconds() + 15 * 60) / 60)  # Adjust for t0
             logger.info(f"5-min satellite delay is only {delay_minutes_5} minutes - Using 5-minutely data.")
             os.system(f"mv {sat_5_path} {sat_path}")
         else:
@@ -68,6 +69,7 @@ def preprocess_sat_data(t0):
         
         ds_sat_15 = xr.open_zarr(sat_15_path)
         latest_time_15 = pd.to_datetime(ds_sat_15.time.max().values)        
+        delay_minutes_15 = int((latest_time_15 - t0).total_seconds() / 60)  # Calculate delay for 15-minute data
         logger.info(f"Latest 15-minute timestamp is {latest_time_15} for t0 time {t0}.")
         
         logger.debug("Resampling 15 minute data to 5 mins")

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -6,7 +6,7 @@ import logging
 import os
 import fsspec
 from datetime import timedelta
-import ocf_blosc2
+#import ocf_blosc2
 
 from pvnet_app.consts import sat_path, nwp_ukv_path, nwp_ecmwf_path
 


### PR DESCRIPTION
# Pull Request

## Description

We calculate delay_minutes_5 by converting sat_delay_5 to seconds, adding 15 minutes for t0, and then converting it to minutes.
The logger.info message for the 5-minute delay now displays the delay in minutes with respect to t0.
Similarly, for the 15-minute delay, we calculate delay_minutes_15 by subtracting t0 from latest_time_15 and converting it to minutes.
The logger.info message for the 15-minute delay also displays the delay in minutes with respect to t0.
The use_15_minute flag is used to determine if the code should switch to using 15-minute data. If it's set, the code proceeds to load and log information about the 15-minute satellite data.