### PR TITLE
update version to 2.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.0.43
+current_version = 2.0.1
 message = Bump version: {current_version} → {new_version} [skip ci]
 
 [bumpversion:file:pvnet_app/__init__.py]


### PR DESCRIPTION
Update version.

Once the pvnet model has been updated to represent the forecast sent in backtest, this should be changed to 2.1.

Forecast sent in backtest was UK national probabilistic with ensembles and ECMWF.