### PR TITLE
Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ ARG TESTING=0
 
 SHELL ["/bin/bash", "-l", "-c"]
 
-RUN apt-get update
-RUN apt-get install git -y
-RUN apt-get install unzip g++ gcc libgeos++-dev libproj-dev proj-data proj-bin -y
+RUN apt-get update && \
+    apt-get install git unzip g++ gcc libgeos++-dev libproj-dev proj-data proj-bin -y
 
 # Copy files
 COPY setup.py app/setup.py


### PR DESCRIPTION
# Pull Request
A line in the Dockerfile is giving me an error when building. Changing the `apt-get` update and install to the same line fixes this

The step
```
RUN apt-get install unzip g++ gcc libgeos++-dev libproj-dev proj-data proj-bin -y
```
gives
``` 
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc-dev-bin_2.31-13%2bdeb11u7_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/l/linux/linux-libc-dev_5.10.197-1_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc6-dev_2.31-13%2bdeb11u7_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/t/tiff/libtiff5_4.2.0-1%2bdeb11u4_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc-devtools_2.31-13%2bdeb11u7_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/c/curl/libcurl4-gnutls-dev_7.74.0-1.3%2bdeb11u10_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/t/tiff/libtiffxx5_4.2.0-1%2bdeb11u4_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/t/tiff/libtiff-dev_4.2.0-1%2bdeb11u4_amd64.deb  404  Not Found [IP: 199.232.150.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
``` 




