### PR TITLE
an option to not save gsp data to forecast_value_last_seven_days

### DIFF
--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -434,7 +434,7 @@ def app(
                     forecasts=sql_forecasts[1:],
                     session=session,
                     update_national=True,
-                    update_gsp=False,
+                    update_gsp=True,
                     apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
                     save_to_last_seven_days=False
 

--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -427,13 +427,13 @@ def app(
                     forecasts=sql_forecasts[0:1],
                     session=session,
                     update_national=True,
-                    update_gsp=True,
+                    update_gsp=False,
                     apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
                 )
                 save_sql_forecasts(
                     forecasts=sql_forecasts[1:],
                     session=session,
-                    update_national=True,
+                    update_national=False,
                     update_gsp=True,
                     apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
                     save_to_last_seven_days=False

--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -427,7 +427,7 @@ def app(
                     forecasts=sql_forecasts[0:1],
                     session=session,
                     update_national=True,
-                    update_gsp=False,
+                    update_gsp=True,
                     apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
                 )
                 save_sql_forecasts(

--- a/pvnet_app/app.py
+++ b/pvnet_app/app.py
@@ -90,6 +90,7 @@ models_dict = {
         "save_gsp_sum": os.getenv("SAVE_GSP_SUM", "false").lower() == "true",
         # Where to log information through prediction steps for this model
         "verbose": True,
+        "save_gsp_to_forecast_value_last_seven_days": True,
     },
     # Extra models which will be run on dev only
     
@@ -107,6 +108,7 @@ models_dict = {
         "use_adjuster": False,
         "save_gsp_sum": False,
         "verbose": False,
+        "save_gsp_to_forecast_value_last_seven_days": False,
     },
     
     "pvnet_v2-ecmwf_only-v9-batches": {
@@ -121,6 +123,7 @@ models_dict = {
         "use_adjuster": False,
         "save_gsp_sum": False,
         "verbose": False,
+        "save_gsp_to_forecast_value_last_seven_days": False,
     },
     
 }
@@ -140,6 +143,7 @@ day_ahead_model_dict = {
         # Since no summation model the sum of GSPs is already calculated
         "save_gsp_sum": False,
         "verbose": True,
+        "save_gsp_to_forecast_value_last_seven_days": True,
     },
 }
 
@@ -408,13 +412,33 @@ def app(
                 model_name=model_name,
                 version=pvnet_app.__version__,
             )
-            save_sql_forecasts(
-                forecasts=sql_forecasts,
-                session=session,
-                update_national=True,
-                update_gsp=True,
-                apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
-            )
+            if model_to_run_dict[model_name]["save_gsp_to_forecast_value_last_seven_days"]:
+
+                save_sql_forecasts(
+                    forecasts=sql_forecasts,
+                    session=session,
+                    update_national=True,
+                    update_gsp=True,
+                    apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
+                )
+            else:
+                # national
+                save_sql_forecasts(
+                    forecasts=sql_forecasts[0:1],
+                    session=session,
+                    update_national=True,
+                    update_gsp=False,
+                    apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
+                )
+                save_sql_forecasts(
+                    forecasts=sql_forecasts[1:],
+                    session=session,
+                    update_national=True,
+                    update_gsp=False,
+                    apply_adjuster=model_to_run_dict[model_name]["use_adjuster"],
+                    save_to_last_seven_days=False
+
+                )
 
             if model_to_run_dict[model_name]["save_gsp_sum"]:
                 # Compute the sum if we are logging the sume of GSPs independently

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torch[cpu]==2.2.0
 PVNet-summation==0.3.0
 pvnet==3.0.47
 ocf_datapipes==3.3.35
-nowcasting_datamodel>=1.5.42
+nowcasting_datamodel>=1.5.45
 fsspec[s3]
 xarray
 zarr

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -74,6 +74,13 @@ def test_app(
     # 318 GSPs * 16 time steps in forecast
     assert len(db_session.query(ForecastValueSQL).all()) == expected_forecast_results * 16
     assert len(db_session.query(ForecastValueLatestSQL).all()) == expected_forecast_results * 16
+
+    expected_forecast_results = 0
+    for model_config in models_dict.values():
+        expected_forecast_results += 1  # national
+        expected_forecast_results += 317 * model_config["save_gsp_to_forecast_value_last_seven_days"]
+        expected_forecast_results += model_config["save_gsp_sum"]  # gsp sum national
+
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == expected_forecast_results * 16
 
 


### PR DESCRIPTION
# Pull Request

## Description

Dont save extra models gsp values to last seven days forecast value table

#93 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
