### PR TITLE
fix for satellite check

### DIFF
--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -127,7 +127,7 @@ def check_model_inputs_available(data_config_filename, sat_delay_mins):
     available = True
     
     # check satellite if using
-    if "satellite" in data_config.input_data:
+    if hasattr(data_config.input_data, "satellite"):
 
         # Take into account how recently the model tries to slice satellite data from
         max_sat_delay_allowed_mins = data_config.input_data.satellite.live_delay_minutes

--- a/pvnet_app/data.py
+++ b/pvnet_app/data.py
@@ -128,21 +128,22 @@ def check_model_inputs_available(data_config_filename, sat_delay_mins):
     
     # check satellite if using
     if hasattr(data_config.input_data, "satellite"):
+        if data_config.input_data.satellite is not None:
 
-        # Take into account how recently the model tries to slice satellite data from
-        max_sat_delay_allowed_mins = data_config.input_data.satellite.live_delay_minutes
+            # Take into account how recently the model tries to slice satellite data from
+            max_sat_delay_allowed_mins = data_config.input_data.satellite.live_delay_minutes
 
-        # Take into account the dropout the model was trained with, if any
-        if data_config.input_data.satellite.dropout_fraction>0:
-            max_sat_delay_allowed_mins = max(
-                max_sat_delay_allowed_mins, 
-                np.abs(data_config.input_data.satellite.dropout_timedeltas_minutes).max()
-            )
+            # Take into account the dropout the model was trained with, if any
+            if data_config.input_data.satellite.dropout_fraction>0:
+                max_sat_delay_allowed_mins = max(
+                    max_sat_delay_allowed_mins,
+                    np.abs(data_config.input_data.satellite.dropout_timedeltas_minutes).max()
+                )
 
-        logger.info(f'Checking satellite data availability, '
-                    f'{sat_delay_mins=} {max_sat_delay_allowed_mins=}')
+            logger.info(f'Checking satellite data availability, '
+                        f'{sat_delay_mins=} {max_sat_delay_allowed_mins=}')
 
-        available = available and (sat_delay_mins <= max_sat_delay_allowed_mins)
+            available = available and (sat_delay_mins <= max_sat_delay_allowed_mins)
         
     return available
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,10 @@ def nwp_ecmwf_data(test_t0):
         test_t0=test_t0,
     )
 
+@pytest.fixture
+def config_filename():
+    return f"{os.path.dirname(os.path.abspath(__file__))}/test_data/test.yaml"
+
 
 def make_sat_data(test_t0, delay_mins, freq_mins):
     # Load dataset which only contains coordinates, but no data

--- a/tests/test_data/test.yaml
+++ b/tests/test_data/test.yaml
@@ -1,0 +1,125 @@
+general:
+  description: Config for training the saved PVNet model
+  name: PVNet current
+git: null
+input_data:
+  data_source_which_defines_geospatial_locations: gsp
+  default_forecast_minutes: 480
+  default_history_minutes: 120
+  gsp:
+    dropout_fraction: 0.0
+    dropout_timedeltas_minutes: null
+    forecast_minutes: 480
+    gsp_image_size_pixels_height: 64
+    gsp_image_size_pixels_width: 64
+    gsp_meters_per_pixel: 2000
+    gsp_zarr_path: PLACEHOLDER.zarr
+    history_minutes: 120
+    is_live: false
+    live_interpolate_minutes: 60
+    live_load_extra_minutes: 60
+    log_level: DEBUG
+    metadata_only: false
+    n_gsp_per_example: 32
+    time_resolution_minutes: 30
+  hrvsatellite: null
+  nwp:
+    ecmwf:
+      dropout_fraction: 1.0
+      dropout_timedeltas_minutes:
+      - -360
+      forecast_minutes: 480
+      history_minutes: 120
+      index_by_id: false
+      log_level: DEBUG
+      max_staleness_minutes: null
+      nwp_accum_channels:
+      - dswrf
+      - dlwrf
+      - sr
+      - duvrs
+      nwp_channels:
+      - t2m
+      - dswrf
+      - dlwrf
+      - hcc
+      - mcc
+      - lcc
+      - tcc
+      - sde
+      - sr
+      - duvrs
+      - u10
+      - v10
+      nwp_image_size_pixels_height: 12
+      nwp_image_size_pixels_width: 12
+      nwp_meters_per_pixel: 2000
+      nwp_provider: ecmwf
+      nwp_zarr_path: PLACEHOLDER.zarr
+      time_resolution_minutes: 60
+      x_dim_name: x_osgb
+      y_dim_name: y_osgb
+    ukv:
+      dropout_fraction: 1.0
+      dropout_timedeltas_minutes:
+      - -180
+      forecast_minutes: 480
+      history_minutes: 120
+      index_by_id: false
+      log_level: DEBUG
+      max_staleness_minutes: null
+      nwp_accum_channels: []
+      nwp_channels:
+      - dlwrf
+      - dswrf
+      - hcc
+      - lcc
+      - mcc
+      - prate
+      - r
+      - sde
+      - si10
+      - t
+      - vis
+      nwp_image_size_pixels_height: 24
+      nwp_image_size_pixels_width: 24
+      nwp_meters_per_pixel: 2000
+      nwp_provider: ukv
+      nwp_zarr_path: PLACEHOLDER.zarr
+      time_resolution_minutes: 60
+      x_dim_name: x_osgb
+      y_dim_name: y_osgb
+  opticalflow: null
+  pv: null
+  satellite:
+    dropout_fraction: 0.2
+    dropout_timedeltas_minutes:
+    - -5
+    - -10
+    - -15
+    forecast_minutes: 0
+    history_minutes: 90
+    is_live: false
+    live_delay_minutes: 30
+    log_level: DEBUG
+    satellite_channels:
+    - IR_016
+    - IR_039
+    - IR_087
+    - IR_097
+    - IR_108
+    - IR_120
+    - IR_134
+    - VIS006
+    - VIS008
+    - WV_062
+    - WV_073
+    satellite_image_size_pixels_height: 24
+    satellite_image_size_pixels_width: 24
+    satellite_meters_per_pixel: 6000
+    satellite_zarr_path: PLACEHOLDER.zarr
+    time_resolution_minutes: 5
+  sensor: null
+  sun: null
+  topographic: null
+  wind: null


### PR DESCRIPTION
# Pull Request

## Description

Fix why satellite data wasnt checked
The fix is to use `hasattr` not `in`

Small code that shows bug
```
from pvnet.models.base_model import BaseModel as PVNetBaseModel
from ocf_datapipes.config.load import load_yaml_configuration

name = "openclimatefix/pvnet_uk_region"
version = "aa73cdafd1db8df3c8b7f5ecfdb160989e7639ac"

data_config_filename = PVNetBaseModel.get_data_config(name, version)
data_config = load_yaml_configuration(data_config_filename)

assert "satellite" in data_config.input_data # this doesnt work
assert hasattr(data_config.input_data, "satellite") # this does
```

## How Has This Been Tested?

Added a test and checked it failed with old code

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
