### PR TITLE
Add hard failure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The following environment variables are used in the app:
   we expect positive forecast values. Defaults to 10 degrees.
 - `FILTER_BAD_FORECASTS`: If set to true and the forecast fails validation checks, it will not be 
   saved. Defaults to false, where all forecasts are saved even if they fail the checks.
-
+- `RAISE_MODEL_FAILURE`: Option to raise an exception if a model fails to run. If set to "any" it 
+  will raise an exception if any model fails. If set to "critical" it will raise an exception if any
+  critical model fails. If not set, it will not raise an exception.
 
 ### Examples
 

--- a/src/pvnet_app/model_configs/all_models.yaml
+++ b/src/pvnet_app/model_configs/all_models.yaml
@@ -111,7 +111,7 @@ models:
     summation:
         repo: openclimatefix/pvnet_summation_uk_national_day_ahead
         commit: 7a2f26b94ac261160358b224944ef32998bd60ce
-    is_critical: False
+    is_critical: True
     is_day_ahead: True
     use_adjuster: True
     save_gsp_sum: True
@@ -166,10 +166,10 @@ models:
     summation:
         repo: openclimatefix/pvnet_summation_uk_national_day_ahead
         commit: ed60c5d32a020242ca4739dcc6dbc8864f783a08
-    is_critical: False
+    is_critical: True
     is_day_ahead: True
     use_adjuster: True
-    ALLOW_SAVE_GSP_SUM: True
+    save_gsp_sum: True
     verbose_logging: True
     save_gsp_to_recent: True
     uses_ocf_data_sampler: False

--- a/src/pvnet_app/utils.py
+++ b/src/pvnet_app/utils.py
@@ -5,6 +5,7 @@ import logging
 
 from ocf_datapipes.batch import NumpyBatch
 
+from pvnet_app.model_configs.pydantic_models import ModelConfig
 
 logger = logging.getLogger()
 
@@ -45,3 +46,36 @@ def save_batch_to_s3(batch: NumpyBatch, model_name: str, s3_directory: str):
         os.remove(save_batch)
     except Exception as e:
         logger.error(f"Failed to save batch to {s3_directory}/{save_batch} with error {e}")
+
+
+def check_model_runs_finished(
+    completed_forecasts: list[str], 
+    model_configs: list[ModelConfig], 
+    raise_if_missing: str,
+) -> None:
+    """Check if the required models have been run and raise an exception if not.
+    
+    Args:
+        completed_forecasts: List of forecast names which have been completed
+        model_configs: List of model configurations
+        raise_if_missing: If set to "any", any missing model will raise an exception.
+            If set to "critical", only missing critical models will raise an exception.
+    """
+    
+    if raise_if_missing=="any":
+        required_forecasts = set([model_config.name for model_config in model_configs])
+        failed_forecasts = required_forecasts - set(completed_forecasts)
+        message = "The following models failed to run"
+    
+    elif raise_if_missing=="critical":
+        required_forecasts = set(
+            [model_config.name for model_config in model_configs if model_config.is_critical]
+        )
+        failed_forecasts = required_forecasts - set(completed_forecasts)
+        message = "The following critical models failed to run"
+    
+    else:
+        raise ValueError(f"Invalid value for raise_if_missing: {raise_if_missing}")
+    
+    if len(failed_forecasts)>0:
+        raise Exception(f"{message}: {failed_forecasts}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from pvnet_app.model_configs.pydantic_models import ModelConfig, HuggingFaceCommit
+from pvnet_app.utils import check_model_runs_finished
+import pytest
+
+
+def test_check_model_runs_finished():
+
+    null_commit = HuggingFaceCommit(repo="dummy", commit="dummy")
+
+    model_configs = [
+        ModelConfig(name="pvnet_v2", is_critical=True, pvnet=null_commit, summation=null_commit),
+        ModelConfig(name="pvnet_test", is_critical=False, pvnet=null_commit, summation=null_commit),
+    ]
+
+    # 1. In this scenario, the critical model has been run but the non-critical model has not
+    completed_forecasts = ["pvnet_v2"]
+
+    # This should not raise an exception since we only check critical models
+    check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="critical")
+
+    # This should raise an exception since we are checking all models
+    with pytest.raises(Exception):
+        check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="any")
+
+    # 2. In this scenario, the critical model has failed but the non-critical model has run
+    completed_forecasts = ["pvnet_test"]
+
+    # This should raise an exception since the critical model has not been run
+    with pytest.raises(Exception):
+        check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="critical")
+
+    # This should raise an exception since a model has not been run
+    with pytest.raises(Exception):
+        check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="any")
+
+    # 3. In this scenario, both models have been run
+    completed_forecasts = ["pvnet_v2", "pvnet_test"]
+
+    # These should not raise an exception since all models have been run
+    check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="critical")
+    check_model_runs_finished(completed_forecasts, model_configs, raise_if_missing="any")
+


### PR DESCRIPTION
## Add hard failure behaviour. 

This adds a new optional env var named `RAISE_MODEL_FAILURE` If set to "any" it will raise an exception if any model fails. If set to "critical" it will raise an exception if any critical model fails. If not set the app will only hard fail if no models can be run.

Partially solves #276 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
