### PR TITLE
fix(entrypoint): Correct entrypoint in container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 
 [project.scripts]
 # Put entrypoints in here
-pvnet-app = "pvnet_app.app:app"
+pvnet-app = "pvnet_app.app:run"
 
 [project.urls]
 repository = "https://github.com/openclimatefix/uk-pvnet-app"

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -371,6 +371,9 @@ def app(
             model_configs=model_configs, 
             raise_if_missing=raise_model_failure,
         )
-
-if __name__ == "__main__":
+        
+def run():
     typer.run(app)
+    
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Ensures that when running the container, arguments can be passed directly e.g.

```
docker run ghcr.io/uk-pvnet-app --num-workers=0
```