### PR TITLE
feat: mark UKV-only model as critical (#357)

### DIFF
--- a/src/pvnet_app/model_configs/all_models.yaml
+++ b/src/pvnet_app/model_configs/all_models.yaml
@@ -104,7 +104,7 @@ models:
     summation:
         repo: openclimatefix/pvnet_v2_summation
         commit: aa60b85f1de69b4fb11da56a2bfb23d04f85e036
-    is_critical: False
+    is_critical: True
     is_day_ahead: False
     use_adjuster: False
     save_gsp_sum: False


### PR DESCRIPTION
Description

This PR marks the UKV-only model as critical in the configuration file
src/pvnet_app/model_configs/all_models.yaml, ensuring it runs in production.

This change addresses Issue #357 – “Make UKV-only model critical”.
No changes to the scheduler or other code logic are required.

Motivation & Context

Marking the UKV-only model as critical is needed to support multiple models in the UI, ensuring consistent model availability in production environments.

Fixes: #357

How Has This Been Tested?

Since this change only updates a configuration flag, no new tests were added.

Checklist:

	•	My code follows [OCF’s coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
	•	I have performed a self-review of my own code
	•	I have made corresponding changes to the documentation (Not required for this config change)
	•	I have added tests that prove my fix is effective or that my feature works (Not applicable)
	•	I have checked my code and corrected any misspellings