### PR TITLE
Fix the data-platform test container in conftests for running local tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ async def wait_for_data_platform_ready(host: str, port: int) -> None:
 
     raise TimeoutError(
         f"Data Platform gRPC endpoint was not ready at {host}:{port} within "
-        f"{DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS} seconds"
+        f"{DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS} seconds",
     ) from last_error
 
 
@@ -102,8 +102,8 @@ def dp_client():
             .with_kwargs(network=postgres_network)
             .waiting_for(
                 PortWaitStrategy(DATA_PLATFORM_GRPC_PORT).with_startup_timeout(
-                    DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS
-                )
+                    DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS,
+                ),
             )
         ) as data_platform_server:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import os
 import time
@@ -13,7 +12,6 @@ import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
 from dp_sdk.ocf import dp
 from grpclib.client import Channel
-from grpclib.exceptions import GRPCError, StreamTerminatedError
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest
 from nowcasting_datamodel.models import GSPYield, LocationSQL
@@ -40,30 +38,6 @@ xr.set_options(keep_attrs=True)
 @pytest.fixture(scope="session")
 def test_t0():
     return pd.Timestamp.now(tz=None).floor(timedelta(minutes=30))
-
-
-async def wait_for_data_platform_ready(host: str, port: int) -> None:
-    """Wait until the Data Platform gRPC endpoint answers a lightweight RPC."""
-    deadline = time.time() + DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS
-    last_error: Exception | None = None
-
-    while time.time() < deadline:
-        channel = Channel(host=host, port=port)
-        client = dp.DataPlatformDataServiceStub(channel)
-
-        try:
-            await client.list_forecasters(dp.ListForecastersRequest(), timeout=2.0)
-            return
-        except (GRPCError, StreamTerminatedError, OSError, TimeoutError) as exc:
-            last_error = exc
-            await asyncio.sleep(1)
-        finally:
-            channel.close()
-
-    raise TimeoutError(
-        f"Data Platform gRPC endpoint was not ready at {host}:{port} within "
-        f"{DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS} seconds",
-    ) from last_error
 
 
 @pytest.fixture(scope="session")
@@ -94,10 +68,10 @@ def dp_client():
 
         with (
             DockerContainer(
-            image=f"ghcr.io/openclimatefix/data-platform:{version('dp_sdk')}",
-            env={"DATABASE_URL": database_url},
-            ports=[DATA_PLATFORM_GRPC_PORT],
-            platform="linux/amd64",
+                image=f"ghcr.io/openclimatefix/data-platform:{version('dp_sdk')}",
+                env={"DATABASE_URL": database_url},
+                ports=[DATA_PLATFORM_GRPC_PORT],
+                platform="linux/amd64",
             )
             .with_kwargs(network=postgres_network)
             .waiting_for(
@@ -106,11 +80,10 @@ def dp_client():
                 ),
             )
         ) as data_platform_server:
+            time.sleep(2)  # Give extra time for the server to start
 
             port = data_platform_server.get_exposed_port(DATA_PLATFORM_GRPC_PORT)
             host = data_platform_server.get_container_host_ip()
-
-            asyncio.run(wait_for_data_platform_ready(host=host, port=port))
 
             # Set env vars so app.py connects to the test container
             os.environ["DATA_PLATFORM_HOST"] = host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import os
 import time
@@ -12,6 +13,7 @@ import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
 from dp_sdk.ocf import dp
 from grpclib.client import Channel
+from grpclib.exceptions import GRPCError, StreamTerminatedError
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest
 from nowcasting_datamodel.models import GSPYield, LocationSQL
@@ -24,9 +26,13 @@ from nowcasting_datamodel.models.forecast import (
 )
 from nowcasting_datamodel.read.read import get_location
 from testcontainers.core.container import DockerContainer
+from testcontainers.core.wait_strategies import PortWaitStrategy
 from testcontainers.postgres import PostgresContainer
 
 test_data_dir = os.path.dirname(os.path.abspath(__file__)) + "/test_data"
+
+DATA_PLATFORM_GRPC_PORT = 50051
+DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS = 60
 
 xr.set_options(keep_attrs=True)
 
@@ -34,6 +40,30 @@ xr.set_options(keep_attrs=True)
 @pytest.fixture(scope="session")
 def test_t0():
     return pd.Timestamp.now(tz=None).floor(timedelta(minutes=30))
+
+
+async def wait_for_data_platform_ready(host: str, port: int) -> None:
+    """Wait until the Data Platform gRPC endpoint answers a lightweight RPC."""
+    deadline = time.time() + DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+
+    while time.time() < deadline:
+        channel = Channel(host=host, port=port)
+        client = dp.DataPlatformDataServiceStub(channel)
+
+        try:
+            await client.list_forecasters(dp.ListForecastersRequest(), timeout=2.0)
+            return
+        except (GRPCError, StreamTerminatedError, OSError, TimeoutError) as exc:
+            last_error = exc
+            await asyncio.sleep(1)
+        finally:
+            channel.close()
+
+    raise TimeoutError(
+        f"Data Platform gRPC endpoint was not ready at {host}:{port} within "
+        f"{DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS} seconds"
+    ) from last_error
 
 
 @pytest.fixture(scope="session")
@@ -51,20 +81,36 @@ def dp_client():
         dbname="postgres",
         env={"POSTGRES_HOST": "db"},
     ) as postgres:
-        database_url = postgres.get_connection_url()
-        database_url = database_url.replace("postgresql+psycopg2", "postgres")
-        database_url = database_url.replace("localhost", "host.docker.internal")
+        postgres_container = postgres.get_wrapped_container()
+        assert postgres_container is not None
 
-        with DockerContainer(
+        docker_client = postgres.get_docker_client()
+        postgres_network = docker_client.network_name(postgres_container.id)
+        postgres_ip = docker_client.bridge_ip(postgres_container.id)
+        database_url = (
+            f"postgres://{postgres.username}:{postgres.password}@"
+            f"{postgres_ip}:{postgres.port}/{postgres.dbname}"
+        )
+
+        with (
+            DockerContainer(
             image=f"ghcr.io/openclimatefix/data-platform:{version('dp_sdk')}",
             env={"DATABASE_URL": database_url},
-            ports=[50051],
+            ports=[DATA_PLATFORM_GRPC_PORT],
             platform="linux/amd64",
+            )
+            .with_kwargs(network=postgres_network)
+            .waiting_for(
+                PortWaitStrategy(DATA_PLATFORM_GRPC_PORT).with_startup_timeout(
+                    DATA_PLATFORM_STARTUP_TIMEOUT_SECONDS
+                )
+            )
         ) as data_platform_server:
-            time.sleep(2)  # Give some time for the server to start
 
-            port = data_platform_server.get_exposed_port(50051)
+            port = data_platform_server.get_exposed_port(DATA_PLATFORM_GRPC_PORT)
             host = data_platform_server.get_container_host_ip()
+
+            asyncio.run(wait_for_data_platform_ready(host=host, port=port))
 
             # Set env vars so app.py connects to the test container
             os.environ["DATA_PLATFORM_HOST"] = host


### PR DESCRIPTION
The current library produces a timeout error when the tests are run locally on a linux machine. This fixes the confest so tests can be run locally
