### PR TITLE
Add option to control saving forecasts to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ this is not set then the `SATELLITE_ZARR_PATH` is used by `.zarr` is repalced wi
   option in the model configs so it is not used. Defaults to true.
 - `ALLOW_SAVE_GSP_SUM`: Option to allow model to save the GSP sum. If false this overwrites the
   model configs so saving of the GSP sum is not used. Defaults to false.
+- `SAVE_TO_DATABASE`: Option to save forecasts to the nowcasting database. Defaults to true.
 
 #### These extra variables control validation and logging
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -102,6 +102,7 @@ async def run(
         - RAISE_MODEL_FAILURE: Option to raise an exception if a model fails to run. If set to
           "any" it will raise an exception if any model fails. If set to "critical" it will raise
           an exception if any critical model fails. If not set, it will not raise an exception.
+        - SAVE_TO_DATABASE: Option to save forecasts to the nowcasting database. Defaults to true.
     """
     # ---------------------------------------------------------------------------
     # 0. Basic set up
@@ -120,6 +121,7 @@ async def run(
     allow_adjuster = get_boolean_env_var("ALLOW_ADJUSTER", default=True)
     allow_save_gsp_sum = get_boolean_env_var("ALLOW_SAVE_GSP_SUM", default=False)
     filter_bad_forecasts = get_boolean_env_var("FILTER_BAD_FORECASTS", default=False)
+    save_to_database = get_boolean_env_var("SAVE_TO_DATABASE", default=True)
     raise_model_failure = os.getenv("RAISE_MODEL_FAILURE", None)
 
     zig_zag_warning_threshold = float(os.getenv("FORECAST_VALIDATE_ZIG_ZAG_WARNING", 250))
@@ -335,11 +337,14 @@ async def run(
     channel.close()
 
     # Write predictions to database
-    logger.info("Writing to database")
+    if save_to_database:
+        logger.info("Writing to database")
 
-    with db_connection.get_session() as session, session.no_autoflush:
-        for forecaster in forecasters.values():
-            forecaster.log_forecast_to_database(session=session)
+        with db_connection.get_session() as session, session.no_autoflush:
+            for forecaster in forecasters.values():
+                forecaster.log_forecast_to_database(session=session)
+    else:
+        logger.info("Skipping writing to database (SAVE_TO_DATABASE is false)")
 
     logger.info("Finished forecast")
 


### PR DESCRIPTION
# Pull Request

## Description

- Added an env var "`SAVE_TO_DATABASE`" to  stop uk-pvnet-app saving to the database
- By default, it saves to databse

Fixes #https://github.com/openclimatefix/client-private/issues/356

## How Has This Been Tested?

Tested with dev data-platform, with the flag `export SAVE_TO_DATABASE=false`

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
