### PR TITLE
Add option to read GSP capacities from data platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The following environment variables are used in the app:
 
 - `SATELLITE_15_ZARR_PATH`: The path to the 15 minute satellite data in Zarr format. If 
 this is not set then the `SATELLITE_ZARR_PATH` is used by `.zarr` is repalced with `_15.zarr`
+- `READ_FROM_DATA_PLATFORM`: Option to read GSP capacities from the data platform instead 
+of the nowcasting database. Defaults to false.
 
 #### These control the model(s) run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,5 +148,5 @@ docstring-code-format = true
 docstring-code-line-length = 100
 
 [tool.uv.sources]
-dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.21.2/dp_sdk-0.21.2-py3-none-any.whl" }
+dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.25.0/dp_sdk-0.25.0-py3-none-any.whl" }
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -16,7 +16,10 @@ from pvnet.models.base_model import BaseModel as PVNetBaseModel
 
 from pvnet_app.config import load_yaml_config
 from pvnet_app.data.batch_validation import check_batch
-from pvnet_app.data.gsp import get_gsp_and_national_capacities
+from pvnet_app.data.gsp import (
+    get_gsp_and_national_capacities,
+    get_gsp_and_national_capacities_from_dp,
+)
 from pvnet_app.data.nwp import CloudcastingDownloader, ECMWFDownloader, UKVDownloader
 from pvnet_app.data.satellite import SatelliteDownloader, get_satellite_source_paths
 from pvnet_app.forecaster import Forecaster
@@ -103,6 +106,8 @@ async def run(
           "any" it will raise an exception if any model fails. If set to "critical" it will raise
           an exception if any critical model fails. If not set, it will not raise an exception.
         - SAVE_TO_DATABASE: Option to save forecasts to the nowcasting database. Defaults to true.
+        - READ_FROM_DATA_PLATFORM: Option to read GSP capacities from the data platform instead
+          of the nowcasting database. Defaults to false.
     """
     # ---------------------------------------------------------------------------
     # 0. Basic set up
@@ -122,6 +127,7 @@ async def run(
     allow_save_gsp_sum = get_boolean_env_var("ALLOW_SAVE_GSP_SUM", default=False)
     filter_bad_forecasts = get_boolean_env_var("FILTER_BAD_FORECASTS", default=False)
     save_to_database = get_boolean_env_var("SAVE_TO_DATABASE", default=True)
+    read_from_data_platform = get_boolean_env_var("READ_FROM_DATA_PLATFORM", default=False)
     raise_model_failure = os.getenv("RAISE_MODEL_FAILURE", None)
 
     zig_zag_warning_threshold = float(os.getenv("FORECAST_VALIDATE_ZIG_ZAG_WARNING", 250))
@@ -178,13 +184,27 @@ async def run(
     if gsp_ids is None:
         gsp_ids = get_gsp_boundaries(version="20250109").iloc[1:].index.tolist()
 
-    # --- Get capacities from the database
-    logger.info("Loading capacities from the database")
-    gsp_capacities, national_capacity = get_gsp_and_national_capacities(
-        db_connection=db_connection,
-        gsp_ids=gsp_ids,
-        t0=t0,
-    )
+    # --- Open the data platform channel if we need it for capacities or for writing forecasts
+    dp_channel: Channel | None = None
+    dp_client: dp.DataPlatformDataServiceStub | None = None
+    if read_from_data_platform or write_predictions:
+        dp_channel = Channel(data_platform_host, data_platform_port)
+        dp_client = dp.DataPlatformDataServiceStub(dp_channel)
+
+    # --- Get capacities
+    if read_from_data_platform:
+        logger.info("Loading capacities from the data platform")
+        gsp_capacities, national_capacity = await get_gsp_and_national_capacities_from_dp(
+            client=dp_client,
+            gsp_ids=gsp_ids,
+        )
+    else:
+        logger.info("Loading capacities from the database")
+        gsp_capacities, national_capacity = get_gsp_and_national_capacities(
+            db_connection=db_connection,
+            gsp_ids=gsp_ids,
+            t0=t0,
+        )
 
     data_downloaders = []
 
@@ -316,25 +336,25 @@ async def run(
     # ---------------------------------------------------------------------------
     # Escape clause for making predictions locally
     if not write_predictions:
+        if dp_channel is not None:
+            dp_channel.close()
         return next(iter(forecasters.values())).da_abs_all
 
     # ---------------------------------------------------------------------------
     # Write predictions to data-platform
     logger.info("Writing to data platform")
-    channel = Channel(data_platform_host, data_platform_port)
-    client = dp.DataPlatformDataServiceStub(channel)
 
-    gsp_uuid_map = await fetch_dp_gsp_uuid_map(client=client)
+    gsp_uuid_map = await fetch_dp_gsp_uuid_map(client=dp_client)
 
     tasks = [
         forecaster.save_forecast_to_dataplatform(
             locations_gsp_uuid_map=gsp_uuid_map,
-            client=client,
+            client=dp_client,
         )
         for forecaster in forecasters.values()
     ]
     await asyncio.gather(*tasks)
-    channel.close()
+    dp_channel.close()
 
     # Write predictions to database
     if save_to_database:

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -7,10 +7,10 @@ from importlib.metadata import version
 import pandas as pd
 import sentry_sdk
 import torch
-from ocf import dp
 from grpclib.client import Channel
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.models.base import Base_Forecast
+from ocf import dp
 from ocf_data_sampler.load.gsp import get_gsp_boundaries
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -7,7 +7,7 @@ from importlib.metadata import version
 import pandas as pd
 import sentry_sdk
 import torch
-from dp_sdk.ocf import dp
+from ocf import dp
 from grpclib.client import Channel
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.models.base import Base_Forecast

--- a/src/pvnet_app/data/gsp.py
+++ b/src/pvnet_app/data/gsp.py
@@ -7,9 +7,9 @@ from importlib.resources import files
 import betterproto
 import numpy as np
 import pandas as pd
-from ocf import dp
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.read.read_gsp import get_latest_gsp_capacities
+from ocf import dp
 
 logger = logging.getLogger()
 

--- a/src/pvnet_app/data/gsp.py
+++ b/src/pvnet_app/data/gsp.py
@@ -1,9 +1,13 @@
-"""Functions to get GSP data from the database."""
+"""Functions to get GSP data from the database or data platform."""
+import asyncio
+import itertools
 import logging
 from importlib.resources import files
 
+import betterproto
 import numpy as np
 import pandas as pd
+from dp_sdk.ocf import dp
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.read.read_gsp import get_latest_gsp_capacities
 
@@ -56,6 +60,76 @@ def get_gsp_and_national_capacities(
         logger.error(f"Error in loading GSP capacities from database: {e}")
         logger.warning(
             "We couldnt load all the capacities from the database, "
+            "so we are using back up ones from 2026-02-04",
+        )
+        national_capacity = BACKUP_CAPACITIES.loc[0].item()
+        gsp_capacities = BACKUP_CAPACITIES.loc[gsp_ids]
+
+    return gsp_capacities, national_capacity
+
+
+async def get_gsp_and_national_capacities_from_dp(
+    client: dp.DataPlatformDataServiceStub,
+    gsp_ids: list[int],
+) -> tuple[pd.Series, float]:
+    """Get GSP and national capacities from the data platform.
+
+    Args:
+        client: Data platform client
+        gsp_ids: List of GSP IDs to get capacities for
+
+    Returns:
+        Tuple containing:
+        - Pandas series of GSP capacities (MWp)
+        - National capacity value (MWp)
+    """
+    try:
+        tasks = [
+            client.list_locations(
+                dp.ListLocationsRequest(
+                    location_type_filter=loc_type,
+                    energy_source_filter=dp.EnergySource.SOLAR,
+                ),
+            )
+            for loc_type in [dp.LocationType.GSP, dp.LocationType.NATION]
+        ]
+        responses = await asyncio.gather(*tasks)
+
+        locations_df = (
+            pd.DataFrame.from_dict(
+                itertools.chain(
+                    *[
+                        r.to_dict(casing=betterproto.Casing.SNAKE, include_default_values=True)[
+                            "locations"
+                        ]
+                        for r in responses
+                    ],
+                ),
+            )
+            .loc[lambda df: df["metadata"].apply(lambda x: "gsp_id" in x)]
+            .assign(
+                gsp_id=lambda df: df["metadata"].apply(
+                    lambda x: int(x["gsp_id"]["number_value"]),
+                ),
+                capacity_mwp=lambda df: df["effective_capacity_watts"] / 1_000_000.0,
+            )
+            .set_index("gsp_id")
+        )
+
+        missing = [gid for gid in [0, *gsp_ids] if gid not in locations_df.index]
+        if missing:
+            raise ValueError(f"Missing capacities from data platform for GSP IDs: {missing}")
+
+        if locations_df.loc[[0, *gsp_ids], "capacity_mwp"].isna().any():
+            raise ValueError("Capacities from data platform contain NaNs")
+
+        national_capacity = float(locations_df.loc[0, "capacity_mwp"])
+        gsp_capacities = locations_df.loc[gsp_ids, "capacity_mwp"]
+
+    except Exception as e:
+        logger.error(f"Error in loading GSP capacities from data platform: {e}")
+        logger.warning(
+            "We couldnt load all the capacities from the data platform, "
             "so we are using back up ones from 2026-02-04",
         )
         national_capacity = BACKUP_CAPACITIES.loc[0].item()

--- a/src/pvnet_app/data/gsp.py
+++ b/src/pvnet_app/data/gsp.py
@@ -7,7 +7,7 @@ from importlib.resources import files
 import betterproto
 import numpy as np
 import pandas as pd
-from dp_sdk.ocf import dp
+from ocf import dp
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.read.read_gsp import get_latest_gsp_capacities
 
@@ -111,9 +111,8 @@ async def get_gsp_and_national_capacities_from_dp(
                 gsp_id=lambda df: df["metadata"].apply(
                     lambda x: int(x["gsp_id"]["number_value"]),
                 ),
-                capacity_mwp=lambda df: df["effective_capacity_watts"] / 1_000_000.0,
-            )
-            .set_index("gsp_id")
+                capacity_mwp=lambda df: df["effective_capacity_watts"].astype(float) / 1_000_000.0,
+            ).set_index("gsp_id")
         )
 
         missing = [gid for gid in [0, *gsp_ids] if gid not in locations_df.index]

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -8,7 +8,7 @@ import torch
 import xarray as xr
 import yaml
 from dateutil.tz import UTC
-from dp_sdk.ocf import dp
+from ocf import dp
 from ocf_data_sampler.numpy_sample.common_types import NumpyBatch
 from ocf_data_sampler.torch_datasets.datasets.pvnet_uk import PVNetUKConcurrentDataset
 from ocf_data_sampler.torch_datasets.utils.torch_batch_utils import (

--- a/src/pvnet_app/save.py
+++ b/src/pvnet_app/save.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
-from dp_sdk.ocf import dp
+from ocf import dp
 from nowcasting_datamodel.models import ForecastSQL, ForecastValue
 from nowcasting_datamodel.read.read import get_latest_input_data_last_updated, get_location
 from nowcasting_datamodel.read.read_models import get_model

--- a/src/pvnet_app/save.py
+++ b/src/pvnet_app/save.py
@@ -13,11 +13,11 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
-from ocf import dp
 from nowcasting_datamodel.models import ForecastSQL, ForecastValue
 from nowcasting_datamodel.read.read import get_latest_input_data_last_updated, get_location
 from nowcasting_datamodel.read.read_models import get_model
 from nowcasting_datamodel.save.save import save as save_sql_forecasts
+from ocf import dp
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
-from dp_sdk.ocf import dp
+from ocf import dp
 from grpclib.client import Channel
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,17 @@ def dp_client():
 
 
 @pytest_asyncio.fixture(scope="session")
+async def client(dp_client):
+    """Create a gRPC client connected to the shared Data Platform server."""
+    host, port = dp_client
+    channel = Channel(host=host, port=port)
+    client_stub = dp.DataPlatformDataServiceStub(channel)
+
+    yield client_stub
+    channel.close()
+
+
+@pytest_asyncio.fixture(scope="session")
 async def setup_dp_locations(dp_client):
     """Set up GSP locations and observer in the shared Data Platform for integration tests."""
     host, port = dp_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ import pytest
 import pytest_asyncio
 import xarray as xr
 from betterproto.lib.google.protobuf import Struct, Value
-from ocf import dp
 from grpclib.client import Channel
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_me_latest
@@ -23,6 +22,7 @@ from nowcasting_datamodel.models.forecast import (
     ForecastValueSQL,
 )
 from nowcasting_datamodel.read.read import get_location
+from ocf import dp
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.wait_strategies import PortWaitStrategy
 from testcontainers.postgres import PostgresContainer

--- a/tests/integration/test_read_from_data_platform.py
+++ b/tests/integration/test_read_from_data_platform.py
@@ -1,0 +1,120 @@
+import datetime
+
+import pandas as pd
+import pytest
+import pytest_asyncio
+from betterproto.lib.google.protobuf import Struct, Value
+from ocf import dp
+from grpclib.client import Channel
+
+from pvnet_app.data.gsp import (
+    BACKUP_CAPACITIES,
+    get_gsp_and_national_capacities_from_dp,
+)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def client(dp_client):
+    """
+    Fixture to create a gRPC client connected to the shared Data Platform server.
+    """
+    host, port = dp_client
+    channel = Channel(host=host, port=port)
+    client_stub = dp.DataPlatformDataServiceStub(channel)
+
+    yield client_stub
+    channel.close()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_gsp_and_national_capacities_from_dp(
+    client: dp.DataPlatformDataServiceStub,
+    setup_dp_locations,  # noqa: ARG001 - ensures locations exist before this test
+):
+    """
+    Test reading GSP and national capacities from the Data Platform.
+
+    The setup_dp_locations fixture creates 1 NATION location (gsp_id=0) and
+    342 GSP locations (gsp_id=1..342), each with effective_capacity_watts=1_000_000 (1 MW).
+
+    In this test we
+    1. request capacities for a subset of GSP ids that were created in setup
+    2. check that the national capacity is read from the gsp_id=0 NATION location
+    3. check that the GSP capacities are returned in the requested order with the right values
+    """
+    gsp_ids = [1, 2, 3, 10, 50, 342]
+
+    gsp_capacities, national_capacity = await get_gsp_and_national_capacities_from_dp(
+        client=client,
+        gsp_ids=gsp_ids,
+    )
+
+    # 2. national capacity comes from the NATION location for gsp_id=0 (1 MW)
+    assert national_capacity == 1.0
+
+    # 3. GSP capacities are a Series indexed by gsp_id, in the order requested
+    assert isinstance(gsp_capacities, pd.Series)
+    assert list(gsp_capacities.index) == gsp_ids
+    assert (gsp_capacities == 1.0).all()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_gsp_and_national_capacities_from_dp_with_custom_capacity(
+    client: dp.DataPlatformDataServiceStub,
+    setup_dp_locations,  # noqa: ARG001 - ensures observer + locations exist before this test
+):
+    """
+    Test that a newly created GSP location's capacity is returned by
+    get_gsp_and_national_capacities_from_dp.
+
+    We pick a gsp_id outside the range created by setup_dp_locations (1..342)
+    so the only matching GSP location for that id is the one created here.
+    """
+    custom_gsp_id = 500
+    custom_capacity_watts = 50_000_000  # 50 MW
+
+    metadata = Struct(fields={"gsp_id": Value(number_value=custom_gsp_id)})
+    create_location_request = dp.CreateLocationRequest(
+        location_name=f"test_read_gsp{custom_gsp_id}",
+        energy_source=dp.EnergySource.SOLAR,
+        geometry_wkt="POINT(20 20)",
+        location_type=dp.LocationType.GSP,
+        effective_capacity_watts=custom_capacity_watts,
+        metadata=metadata,
+        valid_from_utc=datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC),
+    )
+    await client.create_location(create_location_request)
+
+    gsp_capacities, national_capacity = await get_gsp_and_national_capacities_from_dp(
+        client=client,
+        gsp_ids=[custom_gsp_id],
+    )
+
+    assert national_capacity == 1.0
+    assert gsp_capacities.loc[custom_gsp_id] == custom_capacity_watts / 1_000_000.0
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_gsp_and_national_capacities_fallback(
+    client: dp.DataPlatformDataServiceStub,
+    setup_dp_locations,  # noqa: ARG001 - ensures locations exist before this test
+):
+    """
+    Test that the fallback to BACKUP_CAPACITIES is used when a missing GSP ID is requested.
+    
+    If we request a GSP ID that is not found on the data platform, the function 
+    should internally catch the ValueError and return the capacities from the backup CSV.
+    """
+    # GSP ID 348 is in the backup CSV but not created by setup_dp_locations (which creates 1..342)
+    missing_gsp_id = 348
+    
+    gsp_capacities, national_capacity = await get_gsp_and_national_capacities_from_dp(
+        client=client,
+        gsp_ids=[missing_gsp_id],
+    )
+
+    # When fallback occurs, national capacity comes from the backup CSV
+    assert national_capacity == BACKUP_CAPACITIES.loc[0].item()
+    
+    # And GSP capacities come from the backup CSV
+    assert gsp_capacities.loc[missing_gsp_id] == BACKUP_CAPACITIES.loc[missing_gsp_id]

--- a/tests/integration/test_read_from_data_platform.py
+++ b/tests/integration/test_read_from_data_platform.py
@@ -4,8 +4,8 @@ import pandas as pd
 import pytest
 import pytest_asyncio
 from betterproto.lib.google.protobuf import Struct, Value
-from ocf import dp
 from grpclib.client import Channel
+from ocf import dp
 
 from pvnet_app.data.gsp import (
     BACKUP_CAPACITIES,
@@ -101,13 +101,13 @@ async def test_read_gsp_and_national_capacities_fallback(
 ):
     """
     Test that the fallback to BACKUP_CAPACITIES is used when a missing GSP ID is requested.
-    
-    If we request a GSP ID that is not found on the data platform, the function 
+
+    If we request a GSP ID that is not found on the data platform, the function
     should internally catch the ValueError and return the capacities from the backup CSV.
     """
     # GSP ID 348 is in the backup CSV but not created by setup_dp_locations (which creates 1..342)
     missing_gsp_id = 348
-    
+
     gsp_capacities, national_capacity = await get_gsp_and_national_capacities_from_dp(
         client=client,
         gsp_ids=[missing_gsp_id],
@@ -115,6 +115,6 @@ async def test_read_gsp_and_national_capacities_fallback(
 
     # When fallback occurs, national capacity comes from the backup CSV
     assert national_capacity == BACKUP_CAPACITIES.loc[0].item()
-    
+
     # And GSP capacities come from the backup CSV
     assert gsp_capacities.loc[missing_gsp_id] == BACKUP_CAPACITIES.loc[missing_gsp_id]

--- a/tests/integration/test_read_from_data_platform.py
+++ b/tests/integration/test_read_from_data_platform.py
@@ -2,28 +2,13 @@ import datetime
 
 import pandas as pd
 import pytest
-import pytest_asyncio
 from betterproto.lib.google.protobuf import Struct, Value
-from grpclib.client import Channel
 from ocf import dp
 
 from pvnet_app.data.gsp import (
     BACKUP_CAPACITIES,
     get_gsp_and_national_capacities_from_dp,
 )
-
-
-@pytest_asyncio.fixture(scope="session")
-async def client(dp_client):
-    """
-    Fixture to create a gRPC client connected to the shared Data Platform server.
-    """
-    host, port = dp_client
-    channel = Channel(host=host, port=port)
-    client_stub = dp.DataPlatformDataServiceStub(channel)
-
-    yield client_stub
-    channel.close()
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -4,9 +4,7 @@ from importlib.metadata import version
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_asyncio
 from betterproto.lib.google.protobuf import Struct, Value
-from grpclib.client import Channel
 from ocf import dp
 
 from src.pvnet_app.save import (
@@ -14,20 +12,6 @@ from src.pvnet_app.save import (
     limit_adjuster,
     save_forecast_to_data_platform,
 )
-
-
-# @pytest.fixture(scope="session")
-@pytest_asyncio.fixture(scope="session")
-async def client(dp_client):
-    """
-    Fixture to create a gRPC client connected to the shared Data Platform server.
-    """
-    host, port = dp_client
-    channel = Channel(host=host, port=port)
-    client_stub = dp.DataPlatformDataServiceStub(channel)
-
-    yield client_stub
-    channel.close()
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -6,8 +6,8 @@ import pandas as pd
 import pytest
 import pytest_asyncio
 from betterproto.lib.google.protobuf import Struct, Value
-from ocf import dp
 from grpclib.client import Channel
+from ocf import dp
 
 from src.pvnet_app.save import (
     create_forecaster_if_not_exists,

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 import pytest_asyncio
 from betterproto.lib.google.protobuf import Struct, Value
-from dp_sdk.ocf import dp
+from ocf import dp
 from grpclib.client import Channel
 
 from src.pvnet_app.save import (


### PR DESCRIPTION
# Pull Request

## Description

- Added an env var `READ_FROM_DATA_PLATFORM` to read the GSP capacities from the data-platform
- Defaults to false, i.e. read from database

Fixes #https://github.com/openclimatefix/client-private/issues/181

## How Has This Been Tested?

Tested with dev data-platform
- [x] Integration test

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
