### PR TITLE
Add hf token parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "PVNet-summation==1.2.1",
+    "PVNet-summation==1.1.0",
     "fsspec[s3]==2025.2.0",
     "huggingface-hub==0.28.1",
     "nowcasting_datamodel==1.7.2",
     "numpy==2.0.0",
     "ocf_data_sampler==0.6.0",
     "pandas==2.2.3",
-    "pvnet==5.3.0",
+    "pvnet==5.2.0",
     "pydantic==2.5.3",
     "pytorch-lightning==2.3.3",
     "requests==2.32.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "PVNet-summation==1.1.0",
+    "PVNet-summation==1.2.1",
     "fsspec[s3]==2025.2.0",
     "huggingface-hub==0.28.1",
     "nowcasting_datamodel==1.7.2",
     "numpy==2.0.0",
     "ocf_data_sampler==0.6.0",
     "pandas==2.2.3",
-    "pvnet==5.2.0",
+    "pvnet==5.3.0",
     "pydantic==2.5.3",
     "pytorch-lightning==2.3.3",
     "requests==2.32.3",

--- a/scripts/cache_default_models.py
+++ b/scripts/cache_default_models.py
@@ -4,6 +4,8 @@ Downloading these model files in the build means we do not need to download them
 is run.
 """
 
+import os
+
 import typer
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
 from pvnet_summation.models.base_model import BaseModel as SummationBaseModel
@@ -14,9 +16,12 @@ from pvnet_app.app import models_dict
 def main() -> None:
     """Download model from Huggingface and save it to cache."""
     # Model will be downloaded and saved to cache on disk
+    hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
+
     PVNetBaseModel.from_pretrained(
         models_dict["pvnet_v2"]["pvnet"]["name"],
         revision=models_dict["pvnet_v2"]["pvnet"]["version"],
+        token=hf_token,
     )
 
     # Model will be downloaded and saved to cache on disk

--- a/scripts/update_readme_table.py
+++ b/scripts/update_readme_table.py
@@ -3,6 +3,7 @@
 It adds all models in src/pvnet_app/model_configs/all_models.py
 """
 
+import os
 from pathlib import Path
 
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
@@ -36,6 +37,9 @@ def generate_table() -> str:
     separator = "|".join(["----" for _ in columns])
     rows = [header, separator]
 
+    hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
+
+
     for model_config in model_configs:
         pvnet_link = make_huffingface_link(model_config.pvnet)
         summation_link = make_huffingface_link(model_config.summation)
@@ -43,6 +47,7 @@ def generate_table() -> str:
         data_config_path = PVNetBaseModel.get_data_config(
             model_config.pvnet.repo,
             revision=model_config.pvnet.commit,
+            token=hf_token,
         )
         data_config = load_yaml_config(data_config_path)
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -108,6 +108,8 @@ async def run(
         - SAVE_TO_DATABASE: Option to save forecasts to the nowcasting database. Defaults to true.
         - READ_FROM_DATA_PLATFORM: Option to read GSP capacities from the data platform instead
           of the nowcasting database. Defaults to false.
+        - HUGGINGFACE_TOKEN: Huggingface token, required if any of the models being run are in
+          private repositories.
     """
     # ---------------------------------------------------------------------------
     # 0. Basic set up
@@ -129,6 +131,7 @@ async def run(
     save_to_database = get_boolean_env_var("SAVE_TO_DATABASE", default=True)
     read_from_data_platform = get_boolean_env_var("READ_FROM_DATA_PLATFORM", default=False)
     raise_model_failure = os.getenv("RAISE_MODEL_FAILURE", None)
+    hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
 
     zig_zag_warning_threshold = float(os.getenv("FORECAST_VALIDATE_ZIG_ZAG_WARNING", 250))
     zig_zag_error_threshold = float(os.getenv("FORECAST_VALIDATE_ZIG_ZAG_ERROR", 500))
@@ -174,6 +177,7 @@ async def run(
         data_config_path = PVNetBaseModel.get_data_config(
             model_config.pvnet.repo,
             revision=model_config.pvnet.commit,
+            token=hf_token,
         )
         data_config_paths[model_config.name] = data_config_path
         data_configs.append(load_yaml_config(data_config_path))
@@ -274,6 +278,7 @@ async def run(
                 device=device,
                 gsp_capacities=gsp_capacities,
                 national_capacity=national_capacity,
+                hf_token=hf_token,
             )
 
         else:

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -136,14 +136,12 @@ class Forecaster:
             sum_model = SummationBaseModel.from_pretrained(
                 model_id=summation_repo,
                 revision=summation_commit,
-                token=hf_token
             ).to(device)
 
             # Compare the current GSP model with the one the summation model was trained on
             datamodule_path = SummationBaseModel.get_datamodule_config(
                 model_id=summation_repo,
                 revision=summation_commit,
-                token=hf_token
             )
             with open(datamodule_path) as cfg:
                 sum_pvnet_cfg = yaml.safe_load(cfg)["pvnet_model"]

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -126,7 +126,7 @@ class Forecaster:
         model = PVNetBaseModel.from_pretrained(
             model_id=pvnet_repo,
             revision=pvnet_commit,
-            token=hf_token
+            token=hf_token,
         ).to(device)
 
         # Load the summation model

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -1,5 +1,6 @@
 """Functions to run the forecaster."""
 import logging
+import os
 import tempfile
 
 import numpy as np
@@ -77,6 +78,8 @@ class Forecaster:
         self.save_gsp_sum = model_config.save_gsp_sum
         self.save_gsp_to_recent = model_config.save_gsp_to_recent
 
+        self.hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
+
         # Load the GSP and summation models
         self.model, self.summation_model = self.load_model(
             model_config.pvnet.repo,
@@ -84,6 +87,7 @@ class Forecaster:
             model_config.summation.repo,
             model_config.summation.commit,
             device,
+            self.hf_token,
         )
 
         # Values
@@ -104,6 +108,7 @@ class Forecaster:
         summation_repo: str | None,
         summation_commit: str | None,
         device: torch.device,
+        hf_token: bool | str | None = None,
     ) -> tuple[PVNetBaseModel, SummationBaseModel | None]:
         """Load the GSP and summation models.
 
@@ -113,11 +118,15 @@ class Forecaster:
             summation_repo: The huggingface repo of the summation model
             summation_commit: The commit hash of the summation model to load
             device: The device the models will be run on
+            hf_token:
+                HF authentication token. If True, the token is read from the HF config folder.
+                If string, it is used as the authentication token.
         """
         # Load the GSP level model
         model = PVNetBaseModel.from_pretrained(
             model_id=pvnet_repo,
             revision=pvnet_commit,
+            token=hf_token
         ).to(device)
 
         # Load the summation model
@@ -127,12 +136,14 @@ class Forecaster:
             sum_model = SummationBaseModel.from_pretrained(
                 model_id=summation_repo,
                 revision=summation_commit,
+                token=hf_token
             ).to(device)
 
             # Compare the current GSP model with the one the summation model was trained on
             datamodule_path = SummationBaseModel.get_datamodule_config(
                 model_id=summation_repo,
                 revision=summation_commit,
+                token=hf_token
             )
             with open(datamodule_path) as cfg:
                 sum_pvnet_cfg = yaml.safe_load(cfg)["pvnet_model"]

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -1,6 +1,5 @@
 """Functions to run the forecaster."""
 import logging
-import os
 import tempfile
 
 import numpy as np
@@ -50,6 +49,7 @@ class Forecaster:
         device: torch.device,
         gsp_capacities: xr.DataArray,
         national_capacity: float,
+        hf_token: bool | str | None = None,
     ) -> None:
         """Class for making and compiling solar forecasts from for all GB GSPs and national total.
 
@@ -61,6 +61,9 @@ class Forecaster:
             device: Device to run the model on
             gsp_capacities: DataArray of the solar capacities for all regional GSPs at t0
             national_capacity: The national solar capacity at t0
+            hf_token:
+                HF authentication token. If True, the token is read from the HF config folder.
+                If string, it is used as the authentication token.
         """
         self.logger = logging.getLogger(model_config.name)
         self.logger.setLevel(getattr(logging, model_config.log_level))
@@ -78,8 +81,6 @@ class Forecaster:
         self.save_gsp_sum = model_config.save_gsp_sum
         self.save_gsp_to_recent = model_config.save_gsp_to_recent
 
-        self.hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
-
         # Load the GSP and summation models
         self.model, self.summation_model = self.load_model(
             model_config.pvnet.repo,
@@ -87,7 +88,7 @@ class Forecaster:
             model_config.summation.repo,
             model_config.summation.commit,
             device,
-            self.hf_token,
+            hf_token,
         )
 
         # Values
@@ -118,9 +119,7 @@ class Forecaster:
             summation_repo: The huggingface repo of the summation model
             summation_commit: The commit hash of the summation model to load
             device: The device the models will be run on
-            hf_token:
-                HF authentication token. If True, the token is read from the HF config folder.
-                If string, it is used as the authentication token.
+            hf_token: HF authentication token.
         """
         # Load the GSP level model
         model = PVNetBaseModel.from_pretrained(


### PR DESCRIPTION
# Pull Request

## Description

This change passes a HF token as a parameter when getting pvnet regional models from HF repos which allows those repos to be set to private, this change currently is only for pvnet base models so only pvnet regional HF repos can be made private not summation ones.

This is due to dependency complexity since the [passing of hf tokens through the summation base models was only added recently](https://github.com/openclimatefix/pvnet-summation/commit/029fe7ab699d8bf92f5ae40f3c87d51367c05c0b) after other major changes like supporting datasampler v1 so that additional change for summation model repos will be done after the current development branch which includes those changes is merged in. 

Fixes part of https://github.com/openclimatefix/client-private/issues/340


## How Has This Been Tested?

Tested through CI but will also be able to test this on dev by changing the repo to private and manually triggering a run (outside of the usual prod run times) 


**Note:** when this is deployed will need to add [this](https://github.com/openclimatefix/airflow-dags/compare/main...add-HF-toke-uk-forecast-app) to airflow-dags so it can actually access the HF token