### PR TITLE
Update models to remove some UKV inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ export ENVIRONMENT="production"
 <!-- START model-config-table -->
 | Model Name | Uses satellite | Uses UKV | Uses ECMWF | Uses cloudcasting | PVNet Hugging Face Link | PVNet Summation Hugging Face Link |
 | ----|----|----|----|----|----|---- |
-| pvnet_intra_allbells30 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/1ff82a88e890441e4497a59b7d5e6d6836769ff7) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/71acc4c990cf0d0cd9f01dbd1375ec4fa7e1e750) |
-| pvnet_intra_allbells0 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/cc486ad6af6628a5d7c604c5730be748b243bc15) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/474a138e4d8b188e07ef0d34520c896281132bf0) |
+| pvnet_intra_allbells30 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/29071edc6f6ffdba4ce006f95c5291ef73f0258e) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/d756a68fcbafdea4b56226bd3c009d6e327856b9) |
+| pvnet_intra_allbells0 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/87957a7b582c6530ea8f7a81dabfde0206231d54) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/c78e796211f33e6f2561dced07d1de4845fb0bac) |
 | pvnet_da_ecmwf | - | - | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/8cd379ad7769aecd532017976e9658d3fea76e02) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/62d13dbe1458003995f671656e4db5c7b36dc912) |
 | pvnet_intra_sat30 | yes | - | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/5fdc7ec353668d4758455430eea8e10d4c638f1e) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/eb779e7aaa9e0fb5813889a8f9a02d6c518b432a) |
-| pvnet_da_ukv | - | yes | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/4831fc755042b7b311a72b206d62032bfd606c9f) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/aff32fb46f8ecbaf6d5b2664c444a27f6bb160f4) |
-| pvnet_da_2nwp | - | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/03924afeef8c83fb8daf45d555f51f7647c91e6d) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/0b597e230753c7f0e24fb8906cce23b500f96627) |
+| pvnet_da_ukv | - | yes | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/e76e0ee7b823ec544985b91fb0902fdb54469125) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/48ec9568d1f5e1e83618c84a8f53384bbc2c5b74) |
+| pvnet_da_2nwp | - | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/4b519e4bcfc6e784f390131ee310874be90c17c4) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/ad347ddcbce7e8b21d67dea0f93160ab49d4fa50) |
 
 <!-- END model-config-table -->
 

--- a/src/pvnet_app/model_configs/all_models.yaml
+++ b/src/pvnet_app/model_configs/all_models.yaml
@@ -18,13 +18,13 @@ models:
   # ------------------------------------------------------
   
   # Currently this model uses a 30 minute satellite delay
-  - name: pvnet_intra_allbells30 # This name is important as it used for blending
+  - name: pvnet_intra_allbells30
     pvnet:
         repo: openclimatefix-models/pvnet_uk_region
-        commit: 1ff82a88e890441e4497a59b7d5e6d6836769ff7
+        commit: 29071edc6f6ffdba4ce006f95c5291ef73f0258e
     summation:
         repo: openclimatefix-models/pvnet_uk_summation
-        commit: 71acc4c990cf0d0cd9f01dbd1375ec4fa7e1e750
+        commit: d756a68fcbafdea4b56226bd3c009d6e327856b9
     is_critical: True
     is_day_ahead: False
     use_adjuster: True
@@ -37,10 +37,10 @@ models:
   - name: pvnet_intra_allbells0
     pvnet:
         repo: openclimatefix-models/pvnet_uk_region
-        commit: cc486ad6af6628a5d7c604c5730be748b243bc15
+        commit: 87957a7b582c6530ea8f7a81dabfde0206231d54
     summation:
         repo: openclimatefix-models/pvnet_uk_summation
-        commit: 474a138e4d8b188e07ef0d34520c896281132bf0
+        commit: c78e796211f33e6f2561dced07d1de4845fb0bac
     is_critical: False
     is_day_ahead: False
     use_adjuster: False
@@ -85,10 +85,10 @@ models:
   - name: pvnet_da_ukv
     pvnet:
         repo: openclimatefix-models/pvnet_uk_region
-        commit: 4831fc755042b7b311a72b206d62032bfd606c9f
+        commit: e76e0ee7b823ec544985b91fb0902fdb54469125
     summation:
         repo: openclimatefix-models/pvnet_uk_summation
-        commit: aff32fb46f8ecbaf6d5b2664c444a27f6bb160f4
+        commit: 48ec9568d1f5e1e83618c84a8f53384bbc2c5b74
     is_critical: True
     is_day_ahead: True
     use_adjuster: False
@@ -101,10 +101,10 @@ models:
   - name: pvnet_da_2nwp
     pvnet:
         repo: openclimatefix-models/pvnet_uk_region
-        commit: 03924afeef8c83fb8daf45d555f51f7647c91e6d
+        commit: 4b519e4bcfc6e784f390131ee310874be90c17c4
     summation:
         repo: openclimatefix-models/pvnet_uk_summation
-        commit: 0b597e230753c7f0e24fb8906cce23b500f96627
+        commit: ad347ddcbce7e8b21d67dea0f93160ab49d4fa50
     is_critical: True
     is_day_ahead: True
     use_adjuster: True


### PR DESCRIPTION
# Pull Request

## Description

Updates the models to remove many of the UKV variables. This new collection of models now only use the UKV downwards shortwave radiation and no other UKV variables.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
