### PR TITLE
Make runtime download location configurable

### DIFF
--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -1,8 +1,11 @@
-"""Application to run inference for PVNet multiple models."""
+"""Application to run forecasts with a collection of PVNet models."""
+
 
 import asyncio
+import contextlib
 import logging
 import os
+import tempfile
 from importlib.metadata import version
 
 import pandas as pd
@@ -12,7 +15,13 @@ from grpclib.client import Channel
 from ocf import dp
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
 
-from pvnet_app.consts import generation_path
+from pvnet_app.consts import (
+    generation_path,
+    nwp_cloudcasting_path,
+    nwp_ecmwf_path,
+    nwp_ukv_path,
+    sat_path,
+)
 from pvnet_app.data.batch_validation import check_batch
 from pvnet_app.data.gsp import create_null_generation_data
 from pvnet_app.data.nwp import CloudcastingDownloader, ECMWFDownloader, UKVDownloader
@@ -49,23 +58,23 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # ---------------------------------------------------------------------------
 # APP MAIN
 
-async def run(
+async def run_app(
     settings: AppSettings,
     t0: str | None = None,
     write_predictions: bool = True,
-) -> None:
-    """Inference function to run PVNet.
+) -> None | dict:
+    """Set up the app environment and run a forecast.
+
+    Handles Sentry, init-time resolution, and the scratch directory, then
+    delegates to the forecast pipeline.
 
     Args:
         settings: The application settings
-        t0 (str): Datetime at which forecast is made
-        write_predictions (bool): Whether to write prediction to the database. Else returns as
-            DataArray for local testing.
+        t0: The forecast init-time. If None, the current time is used. Floored
+            to the previous 30-minute mark and made naive-UTC before running
+        write_predictions: If True, write forecasts to the data platform. If
+            False, skip the write and return the forecasters for local testing
     """
-    # ---------------------------------------------------------------------------
-    # Basic set up
-
-    # -- Initialize Sentry
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
         environment=settings.environment,
@@ -76,15 +85,50 @@ async def run(
 
     # If inference datetime is None, set to now
     t0 = pd.Timestamp.now(tz="UTC") if t0 is None else pd.Timestamp(t0).tz_localize("UTC")
-    # Round down to last 30 minutes
     t0 = t0.replace(tzinfo=None).floor("30min")
 
-    # --- Log version and variables
-    pvnet_version = version("pvnet")
-    logger.info(f"Using `pvnet` library version: {pvnet_version}")
+    logger.info(f"Using `pvnet` library version: {version('pvnet')}")
     logger.info(f"Using `pvnet_app` library version: {__version__}")
     logger.info(f"Making forecast for init time: {t0}")
     logger.info(f"Running critical models only: {settings.run_critical_models_only}")
+
+    # If a scratch directory is configured, use it. Otherwise, create a temporary directory which
+    # will be deleted after the forecast is complete.
+    if settings.scratch_dir is not None:
+        logger.info(f"Using configured scratch directory: {settings.scratch_dir}")
+        # Create the scratch directory if it doesn't exist. If it does exist, raise an error to
+        # avoid clashing with data from a previous run.
+        os.makedirs(settings.scratch_dir, exist_ok=False)
+        dir_context = contextlib.nullcontext(settings.scratch_dir)
+    else:
+        logger.info("No scratch directory configured. Creating a temporary scratch directory.")
+        dir_context = tempfile.TemporaryDirectory(prefix="pvnet-app-")
+
+    with dir_context as scratch_dir:
+        logger.info(f"Using scratch directory: {scratch_dir}")
+        return await _run_forecast_pipeline(settings, t0, scratch_dir, write_predictions)
+
+
+async def _run_forecast_pipeline(
+    settings: AppSettings,
+    t0: pd.Timestamp,
+    scratch_dir: str,
+    write_predictions: bool,
+) -> dict | None:
+    """Run the forecast pipeline for all configured models.
+
+    Prepares inputs, runs each model whose data is available, validates the
+    forecasts, and writes them to the data platform.
+
+    Args:
+        settings: The application settings
+        t0: The forecast init-time. Must be in naive-UTC and floored to 30 minutes
+        scratch_dir: Directory for downloaded inputs and temporary files
+        write_predictions: If True, write forecasts to the data platform. If
+            False, skip the write and return the forecasters for local testing
+    """
+    # ---------------------------------------------------------------------------
+    # Basic set up
 
     # --- Get the model configurations
     model_specs = get_model_specs(get_critical_only=settings.run_critical_models_only)
@@ -92,7 +136,7 @@ async def run(
     if len(model_specs) == 0:
         raise Exception("No models found after filtering")
 
-    # Get Model configs
+    # Fetch the model's data configs
     data_config_paths: dict[str, str] = {}
     data_configs: list[dict] = []
     for model_spec in model_specs:
@@ -119,7 +163,7 @@ async def run(
         capacities_mwp=extract_location_capacities_mwp(locations),
     )
 
-    ds_gen.to_zarr(generation_path)
+    ds_gen.to_zarr(f"{scratch_dir}/{generation_path}")
 
     national_capacity = ds_gen.sel(time_utc=t0, location_id=0).capacity_mwp.item()
     gsp_capacities = ds_gen.sel(time_utc=t0, location_id=slice(1, None)).capacity_mwp.values
@@ -136,6 +180,7 @@ async def run(
             source_path_5=settings.satellite_icechunk_path_5,
             source_path_15=settings.satellite_icechunk_path_15,
             s3_region=settings.satellite_s3_region,
+            destination_path=f"{scratch_dir}/{sat_path}",
         )
         sat_downloader.run()
 
@@ -153,13 +198,19 @@ async def run(
                     required_providers.add(source["provider"])
 
         if "ukv" in required_providers:
-            ukv_downloader = UKVDownloader(source_path=settings.nwp_ukv_zarr_path)
+            ukv_downloader = UKVDownloader(
+                source_path=settings.nwp_ukv_zarr_path,
+                destination_path=f"{scratch_dir}/{nwp_ukv_path}",
+            )
             ukv_downloader.run()
 
             data_downloaders.append(ukv_downloader)
 
         if "ecmwf" in required_providers:
-            ecmwf_downloader = ECMWFDownloader(source_path=settings.nwp_ecmwf_zarr_path)
+            ecmwf_downloader = ECMWFDownloader(
+                source_path=settings.nwp_ecmwf_zarr_path,
+                destination_path=f"{scratch_dir}/{nwp_ecmwf_path}",
+            )
             ecmwf_downloader.run()
 
             data_downloaders.append(ecmwf_downloader)
@@ -167,6 +218,7 @@ async def run(
         if "cloudcasting" in required_providers:
             cloudcasting_downloader = CloudcastingDownloader(
                 source_path=settings.cloudcasting_zarr_path,
+                destination_path=f"{scratch_dir}/{nwp_cloudcasting_path}",
             )
             cloudcasting_downloader.run()
 
@@ -194,6 +246,7 @@ async def run(
             forecasters[model_spec.name] = Forecaster(
                 model_spec=model_spec,
                 data_config_path=data_config_path,
+                run_data_dir=scratch_dir,
                 t0=t0,
                 gsp_ids=gsp_ids,
                 device=device,
@@ -224,10 +277,6 @@ async def run(
             save_batch_to_s3(batch, model_name, settings.save_batches_dir)
 
         forecaster.predict(batch)
-
-    # Delete the downloaded data
-    for downloader in data_downloaders:
-        downloader.clean_up()
 
     # ---------------------------------------------------------------------------
     # Run validation checks on the forecast values
@@ -312,4 +361,4 @@ async def run(
 def main() -> None:
     """Main entrypoint to the inference app."""
     settings = AppSettings()
-    asyncio.run(run(settings=settings))
+    asyncio.run(run_app(settings=settings))

--- a/src/pvnet_app/data/nwp.py
+++ b/src/pvnet_app/data/nwp.py
@@ -13,8 +13,6 @@ import xarray as xr
 import xesmf as xe
 from ocf_data_sampler.config.load import load_yaml_configuration
 
-from pvnet_app.consts import nwp_cloudcasting_path, nwp_ecmwf_path, nwp_ukv_path
-
 logger = logging.getLogger(__name__)
 
 
@@ -133,13 +131,13 @@ def check_model_nwp_inputs_available(
 
 class NWPDownloader(ABC):
     """Abstract base class to download and process NWP data."""
-    destination_path: str = None
     nwp_source: str = None
     save_chunk_dict: dict = None
 
-    def __init__(self, source_path: str | None) -> None:
+    def __init__(self, source_path: str | None, destination_path: str) -> None:
         """Initialise the NWP downloader."""
         self.source_path = source_path
+        self.destination_path = destination_path
         # Initially no valid times are available. This will only change is the data can be
         # downloaded, processed, and saved successfully
         self.valid_times = None
@@ -210,10 +208,6 @@ class NWPDownloader(ABC):
         # quality checked, and processed. Else valid_times will be None
         self.valid_times = valid_times
 
-    def clean_up(self) -> None:
-        """Remove the downloaded data."""
-        shutil.rmtree(self.destination_path, ignore_errors=True)
-
     def check_model_inputs_available(
         self,
         data_config_filename: str,
@@ -235,7 +229,6 @@ class NWPDownloader(ABC):
 
 class ECMWFDownloader(NWPDownloader):
     """Class to download and process the ECMWF data."""
-    destination_path = nwp_ecmwf_path
     nwp_source = "ecmwf"
     save_chunk_dict = { # noqa: RUF012
         "step": 10,
@@ -255,7 +248,6 @@ class ECMWFDownloader(NWPDownloader):
 
 class UKVDownloader(NWPDownloader):
     """Class to download and process the UKV data."""
-    destination_path = nwp_ukv_path
     nwp_source = "ukv"
     save_chunk_dict = { # noqa: RUF012
         "step": 10,
@@ -338,7 +330,6 @@ class UKVDownloader(NWPDownloader):
 
 class CloudcastingDownloader(NWPDownloader):
     """Class to download and process the cloudcasting data."""
-    destination_path = nwp_cloudcasting_path
     nwp_source = "cloudcasting"
     save_chunk_dict: dict[str, int] = { # noqa: RUF012
         "step": -1,

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -12,7 +12,6 @@ from ocf_data_sampler.select.geospatial import convert_coordinates
 from ocf_data_sampler.select.location import Location
 from ocf_data_sampler.select.select_spatial_slice import select_spatial_slice_pixels_multiple
 
-from pvnet_app.consts import sat_path
 from pvnet_app.data.gsp import get_gsp_locations
 
 logger = logging.getLogger(__name__)
@@ -325,7 +324,6 @@ def contains_too_many_of_value(ds: xr.Dataset, value: float, threshold: float) -
 
 class SatelliteDownloader:
     """Class to download and process satellite data."""
-    destination_path: str = sat_path
 
     def __init__(
         self,
@@ -333,6 +331,7 @@ class SatelliteDownloader:
         source_path_5: str | None,
         source_path_15: str | None,
         s3_region: str,
+        destination_path: str,
     ) -> None:
         """Class to download and process satellite data."""
         self.t0 = t0
@@ -342,7 +341,7 @@ class SatelliteDownloader:
         self.time_window = pd.Timedelta("1h")
         self.valid_times = None
         self.sat_choice = None
-
+        self.destination_path = destination_path
 
     @staticmethod
     def data_is_okay(ds: xr.Dataset) -> bool:
@@ -470,6 +469,3 @@ class SatelliteDownloader:
             sat_datetimes=self.valid_times,
         )
 
-    def clean_up(self) -> None:
-        """Remove the downloaded data."""
-        shutil.rmtree(self.destination_path, ignore_errors=True)

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -1,6 +1,5 @@
 """Functions to run the forecaster."""
 import logging
-import tempfile
 
 import numpy as np
 import pandas as pd
@@ -54,18 +53,21 @@ class Forecaster:
         self,
         model_spec: ModelSpec,
         data_config_path: str,
+        run_data_dir: str,
         t0: pd.Timestamp,
         gsp_ids: list[int],
         device: torch.device,
         gsp_capacities: xr.DataArray,
         national_capacity: float,
         hf_token: bool | str | None = None,
+
     ) -> None:
         """Class for making and compiling solar forecasts from for all GB GSPs and national total.
 
         Args:
             model_spec: The configuration for the model
             data_config_path: The path to the model data config
+            run_data_dir: The directory where the downloaded input data is stored
             t0: The forecast init-time
             gsp_ids: List of gsp_ids to make predictions for
             device: Device to run the model on
@@ -82,6 +84,7 @@ class Forecaster:
         # Store settings
         self.model_tag = model_spec.name
         self.data_config_path = data_config_path
+        self.run_data_dir = run_data_dir
         self.t0 = t0
         self.gsp_ids = gsp_ids
         self.device = device
@@ -164,15 +167,15 @@ class Forecaster:
 
     def make_batch(self) -> NumpyBatch:
         """Create the batch required to run this model."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as tmp:
-            temp_path = tmp.name
+        runtime_data_config_filepath = f"{self.run_data_dir}/{self.model_tag}_data_config.yaml"
 
-            modify_data_config_for_production(
-                input_path=self.data_config_path,
-                output_path=temp_path,
-            )
+        modify_data_config_for_production(
+            input_path=self.data_config_path,
+            output_path=runtime_data_config_filepath,
+            run_data_dir=self.run_data_dir,
+        )
 
-            dataset = PVNetConcurrentDataset(config_filename=temp_path)
+        dataset = PVNetConcurrentDataset(config_filename=runtime_data_config_filepath)
 
         return dataset.get_sample(self.t0)
 

--- a/src/pvnet_app/model_input_config.py
+++ b/src/pvnet_app/model_input_config.py
@@ -31,24 +31,25 @@ def save_yaml_config(config: dict, path: str) -> None:
         yaml.dump(config, file, default_flow_style=False)
 
 
-def populate_config_with_data_filepaths(config: dict) -> dict:
+def populate_config_with_data_filepaths(config: dict, run_data_dir: str) -> dict:
     """Populate the data source filepaths in the config.
 
     Args:
         config: The data config
+        run_data_dir: The directory where the downloaded input data is stored
     """
     nwp_paths = {
-        "ukv": nwp_ukv_path,
-        "ecmwf": nwp_ecmwf_path,
-        "cloudcasting": nwp_cloudcasting_path,
+        "ukv": f"{run_data_dir}/{nwp_ukv_path}",
+        "ecmwf": f"{run_data_dir}/{nwp_ecmwf_path}",
+        "cloudcasting": f"{run_data_dir}/{nwp_cloudcasting_path}",
     }
 
     # Set the GSP input path
-    config["input_data"]["generation"]["zarr_path"] = generation_path
+    config["input_data"]["generation"]["zarr_path"] = f"{run_data_dir}/{generation_path}"
 
     # Replace satellite data path
     if "satellite" in config["input_data"]:
-        config["input_data"]["satellite"]["zarr_path"] = sat_path
+        config["input_data"]["satellite"]["zarr_path"] = f"{run_data_dir}/{sat_path}"
 
     # NWP is nested so much be treated separately
     if "nwp" in config["input_data"]:
@@ -85,17 +86,17 @@ def overwrite_config_dropouts(config: dict) -> dict:
     return config
 
 
-def modify_data_config_for_production(input_path: str, output_path: str) -> None:
+def modify_data_config_for_production(input_path: str, output_path: str, run_data_dir: str) -> None:
     """Resave the data config with the data source filepaths and dropouts overwritten.
 
     Args:
         input_path: Path to input configuration file
         output_path: Location to save the output configuration file
-        reformat_config: Reformat config to new format
+        run_data_dir: The directory where the downloaded input data is stored
     """
     config = load_yaml_config(input_path)
 
-    config = populate_config_with_data_filepaths(config)
+    config = populate_config_with_data_filepaths(config, run_data_dir=run_data_dir)
     config = overwrite_config_dropouts(config)
 
     save_yaml_config(config, output_path)

--- a/src/pvnet_app/settings.py
+++ b/src/pvnet_app/settings.py
@@ -40,6 +40,8 @@ class AppSettings(BaseSettings):
         - HUGGINGFACE_TOKEN: Huggingface token, required if any of the models being run are in
           private repositories.
         - SAVE_BATCHES_DIR: If set, the batches will be saved to this path.
+        - SCRATCH_DIR: If set, the scratch directory will be used for temporary files. Else, the
+          system temp directory will be used.
     """
 
     # Input data paths
@@ -66,3 +68,4 @@ class AppSettings(BaseSettings):
     data_platform_port: int = 50051
     huggingface_token: str | None = None
     save_batches_dir: str | None = None
+    scratch_dir: str | None = None

--- a/tests/data/test_nwp.py
+++ b/tests/data/test_nwp.py
@@ -1,5 +1,4 @@
-import os
-import tempfile
+from pathlib import Path
 
 import pandas as pd
 import xarray as xr
@@ -11,26 +10,33 @@ def test_download_nwp(
     nwp_ukv_data: xr.Dataset,
     nwp_ecmwf_data: xr.Dataset,
     cloudcasting_data: xr.Dataset,
+    tmp_path: Path,
 ):
-    temp_ukv_path = "temp_nwp_ukv.zarr"
-    temp_ecmwf_path = "temp_nwp_ecmwf.zarr"
-    temp_cloudcasting_path = "temp_cloudcasting.zarr"
+    source_ukv_path = f"{tmp_path}/source_ukv.zarr"
+    source_ecmwf_path = f"{tmp_path}/source_ecmwf.zarr"
+    source_cloudcasting_path = f"{tmp_path}/source_cloudcasting.zarr"
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    nwp_ukv_data.to_zarr(source_ukv_path)
+    nwp_ecmwf_data.to_zarr(source_ecmwf_path)
+    cloudcasting_data.to_zarr(source_cloudcasting_path)
 
-        nwp_ukv_data.to_zarr(temp_ukv_path)
-        nwp_ecmwf_data.to_zarr(temp_ecmwf_path)
-        cloudcasting_data.to_zarr(temp_cloudcasting_path)
+    ukv_downloader = UKVDownloader(
+        source_path=source_ukv_path,
+        destination_path=f"{tmp_path}/ukv.zarr",
+    )
+    ukv_downloader.run()
 
-        ukv_downloader = UKVDownloader(source_path=temp_ukv_path)
-        ukv_downloader.run()
+    ecmwf_downloader = ECMWFDownloader(
+        source_path=source_ecmwf_path,
+        destination_path=f"{tmp_path}/ecmwf.zarr",
+    )
+    ecmwf_downloader.run()
 
-        ecmwf_downloader = ECMWFDownloader(source_path=temp_ecmwf_path)
-        ecmwf_downloader.run()
-
-        cloudcasting_downloader = CloudcastingDownloader(source_path=temp_cloudcasting_path)
-        cloudcasting_downloader.run()
+    cloudcasting_downloader = CloudcastingDownloader(
+        source_path=source_cloudcasting_path,
+        destination_path=f"{tmp_path}/cloudcasting.zarr",
+    )
+    cloudcasting_downloader.run()
 
 
 def test_check_model_nwp_inputs_available(
@@ -38,56 +44,72 @@ def test_check_model_nwp_inputs_available(
     test_t0: pd.Timestamp,
     nwp_ukv_data: xr.Dataset,
     nwp_ecmwf_data: xr.Dataset,
+    tmp_path: Path,
 ):
-    temp_ukv_path = "temp_nwp_ukv.zarr"
-    temp_ecmwf_path = "temp_nwp_ecmwf.zarr"
 
-    # Test in a case where all inputs are available
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    # ---- Test case where all inputs are available
 
-        # Create the required NWP data
-        nwp_ukv_data.to_zarr(temp_ukv_path)
-        nwp_ecmwf_data.to_zarr(temp_ecmwf_path)
+    # Create the required NWP data
+    source_ukv_path = f"{tmp_path}/source_ukv.zarr"
+    source_ecmwf_path = f"{tmp_path}/source_ecmwf.zarr"
 
-        ukv_downloader = UKVDownloader(source_path=temp_ukv_path)
-        ukv_downloader.run()
+    nwp_ukv_data.to_zarr(source_ukv_path)
+    nwp_ecmwf_data.to_zarr(source_ecmwf_path)
 
-        ecmwf_downloader = ECMWFDownloader(source_path=temp_ecmwf_path)
-        ecmwf_downloader.run()
+    ukv_downloader = UKVDownloader(
+        source_path=source_ukv_path,
+        destination_path=f"{tmp_path}/ukv.zarr",
+    )
+    ukv_downloader.run()
 
-        # The inputs are all available so these should return True
-        assert ukv_downloader.check_model_inputs_available(config_filename, test_t0)
-        assert ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)
+    ecmwf_downloader = ECMWFDownloader(
+        source_path=source_ecmwf_path,
+        destination_path=f"{tmp_path}/ecmwf.zarr",
+    )
+    ecmwf_downloader.run()
 
-    # Test in a case where no NWP data is available
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    # The inputs are all available so these should return True
+    assert ukv_downloader.check_model_inputs_available(config_filename, test_t0)
+    assert ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)
 
-        ukv_downloader = UKVDownloader(source_path=temp_ukv_path)
-        ukv_downloader.run()
+    # ---- Test case where no NWP data is available
+    ukv_downloader = UKVDownloader(
+        source_path="empty_ukv_path.zarr",
+        destination_path="dummy.zarr",
+    )
+    ukv_downloader.run()
 
-        ecmwf_downloader = ECMWFDownloader(source_path=temp_ecmwf_path)
-        ecmwf_downloader.run()
+    ecmwf_downloader = ECMWFDownloader(
+        source_path="empty_ecmwf_path.zarr",
+        destination_path="dummy.zarr",
+    )
+    ecmwf_downloader.run()
 
-        # No inputs are available so these should return False
-        assert not ukv_downloader.check_model_inputs_available(config_filename, test_t0)
-        assert not ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)
+    # No inputs are available so these should return False
+    assert not ukv_downloader.check_model_inputs_available(config_filename, test_t0)
+    assert not ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)
 
-    # Test in a case where NWP data is available but not all the required time steps
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    # ---- Test case where NWP data is available but not all the required time steps
 
-        # Save the NWP data, but with less time steps
-        nwp_ukv_data.isel(step=slice(0, 4)).to_zarr(temp_ukv_path)
-        nwp_ecmwf_data.isel(step=slice(0, 4)).to_zarr(temp_ecmwf_path)
+    # Save the NWP data, but with less time steps
+    source_ukv_path = f"{tmp_path}/short_source_ukv.zarr"
+    source_ecmwf_path = f"{tmp_path}/short_source_ecmwf.zarr"
 
-        ukv_downloader = UKVDownloader(source_path=temp_ukv_path)
-        ukv_downloader.run()
+    nwp_ukv_data.isel(step=slice(0, 4)).to_zarr(source_ukv_path)
+    nwp_ecmwf_data.isel(step=slice(0, 4)).to_zarr(source_ecmwf_path)
 
-        ecmwf_downloader = ECMWFDownloader(source_path=temp_ecmwf_path)
-        ecmwf_downloader.run()
+    ukv_downloader = UKVDownloader(
+        source_path=source_ukv_path,
+        destination_path=f"{tmp_path}/short_ukv.zarr",
+    )
+    ukv_downloader.run()
 
-        # Some steps are missing so these should return False
-        assert not ukv_downloader.check_model_inputs_available(config_filename, test_t0)
-        assert not ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)
+    ecmwf_downloader = ECMWFDownloader(
+        source_path=source_ecmwf_path,
+        destination_path=f"{tmp_path}/short_ecmwf.zarr",
+    )
+    ecmwf_downloader.run()
+
+    # Some steps are missing so these should return False
+    assert not ukv_downloader.check_model_inputs_available(config_filename, test_t0)
+    assert not ecmwf_downloader.check_model_inputs_available(config_filename, test_t0)

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -1,12 +1,11 @@
 import os
-import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from pvnet_app.consts import sat_path
 from pvnet_app.data.satellite import (
     SatelliteDownloader,
     check_model_satellite_inputs_available,
@@ -32,106 +31,108 @@ def timesteps_match_expected_freq(sat_path: str, expected_freq_mins: int | list[
     return np.isin(dts, pd.to_timedelta(expected_freq_mins, unit="min")).all()
 
 
-def test_run_sat_5_data(sat_5_data: xr.Dataset, test_t0: pd.Timestamp):
+def test_run_sat_5_data(sat_5_data: xr.Dataset, test_t0: pd.Timestamp, tmp_path: Path):
     """Download and process only the 5 minute satellite data"""
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    dst_path = f"{tmp_path}/sat.zarr"
 
-        with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[sat_5_data]):
+    with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[sat_5_data]):
 
-            sat_downloader = SatelliteDownloader(
-                t0=test_t0,
-                source_path_5="s3://fake/sat5",
-                source_path_15=None,
-                s3_region="fake-region",
-            )
-            sat_downloader.run()
-
-        assert os.path.exists(sat_path)
-        assert sat_downloader.sat_choice == "5-min"
-
-        # Check the satellite data is 5-minutely and is saved in the correct place
-        assert timesteps_match_expected_freq(sat_path, expected_freq_mins=5)
+        sat_downloader = SatelliteDownloader(
+            t0=test_t0,
+            source_path_5="s3://fake/sat5",
+            source_path_15=None,
+            s3_region="fake-region",
+            destination_path=dst_path,
+        )
+        sat_downloader.run()
 
 
-def test_run_sat_15_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp):
+    assert os.path.exists(dst_path)
+    assert sat_downloader.sat_choice == "5-min"
+
+    # Check the satellite data is 5-minutely and is saved in the correct place
+    assert timesteps_match_expected_freq(dst_path, expected_freq_mins=5)
+
+
+def test_run_sat_15_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp_path: Path):
     """Download and process only the 15 minute satellite data"""
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    dst_path = f"{tmp_path}/sat.zarr"
 
-        with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[sat_15_data]):
+    with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[sat_15_data]):
 
-            sat_downloader = SatelliteDownloader(
-                t0=test_t0,
-                source_path_5=None,
-                source_path_15="s3://fake/sat15",
-                s3_region="fake-region",
-            )
-            sat_downloader.run()
+        sat_downloader = SatelliteDownloader(
+            t0=test_t0,
+            source_path_5=None,
+            source_path_15="s3://fake/sat15",
+            s3_region="fake-region",
+            destination_path=dst_path,
+        )
+        sat_downloader.run()
 
-        assert os.path.exists(sat_path)
-        assert sat_downloader.sat_choice == "15-min"
+    assert os.path.exists(dst_path)
+    assert sat_downloader.sat_choice == "15-min"
 
-        # We infill the satellite data to 5 minutes in the process step
-        assert timesteps_match_expected_freq(sat_path, expected_freq_mins=5)
+    # We infill the satellite data to 5 minutes in the process step
+    assert timesteps_match_expected_freq(dst_path, expected_freq_mins=5)
 
 
 def test_run_sat_delayed_5_and_15_data(
     sat_5_data_delayed: xr.Dataset,
     sat_15_data: xr.Dataset,
     test_t0: pd.Timestamp,
+    tmp_path: Path,
 ):
     """Download and process 5 and 15 minute satellite data. Use the 15 minute data since the
     5 minute data is too delayed
     """
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    dst_path = f"{tmp_path}/sat.zarr"
 
-        with patch(
-            "pvnet_app.data.satellite.open_satellite_data",
-            side_effect=[sat_5_data_delayed, sat_15_data],
-        ):
-            sat_downloader = SatelliteDownloader(
-                t0=test_t0,
-                source_path_5="s3://fake/sat5",
-                source_path_15="s3://fake/sat15",
-                s3_region="fake-region",
-            )
-            sat_downloader.run()
+    with patch(
+        "pvnet_app.data.satellite.open_satellite_data",
+        side_effect=[sat_5_data_delayed, sat_15_data],
+    ):
+        sat_downloader = SatelliteDownloader(
+            t0=test_t0,
+            source_path_5="s3://fake/sat5",
+            source_path_15="s3://fake/sat15",
+            s3_region="fake-region",
+            destination_path=dst_path,
+        )
+        sat_downloader.run()
 
-        assert os.path.exists(sat_path)
-        assert sat_downloader.sat_choice == "15-min"
+    assert os.path.exists(dst_path)
+    assert sat_downloader.sat_choice == "15-min"
 
-        # We infill the satellite data to 5 minutes in the process step
-        assert timesteps_match_expected_freq(sat_path, expected_freq_mins=5)
+    # We infill the satellite data to 5 minutes in the process step
+    assert timesteps_match_expected_freq(dst_path, expected_freq_mins=5)
 
 
-def test_run_nan_in_sat_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp):
+def test_run_nan_in_sat_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp_path: Path):
     """Check that the satellite data is considered invalid if it contains too many NaNs"""
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    dst_path = f"{tmp_path}/sat.zarr"
 
-        # Make half the values zeros
-        ds = sat_15_data.copy(deep=True)
-        ds.data[::2] = np.nan
+    # Make half the values zeros
+    ds = sat_15_data.copy(deep=True)
+    ds.data[::2] = np.nan
 
-        with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[ds]):
-            sat_downloader = SatelliteDownloader(
-                t0=test_t0,
-                source_path_5=None,
-                source_path_15="s3://fake/sat15",
-                s3_region="fake-region",
-            )
-            sat_downloader.run()
+    with patch("pvnet_app.data.satellite.open_satellite_data", side_effect=[ds]):
+        sat_downloader = SatelliteDownloader(
+            t0=test_t0,
+            source_path_5=None,
+            source_path_15="s3://fake/sat15",
+            s3_region="fake-region",
+            destination_path=dst_path,
+        )
+        sat_downloader.run()
 
-        # If the satellite data is invalid the valid_times attribute should be None and the
-        # satellite data should not be saved
-        assert sat_downloader.valid_times is None
-        assert not os.path.exists(sat_path)
+    # If the satellite data is invalid the valid_times attribute should be None and the
+    # satellite data should not be saved
+    assert sat_downloader.valid_times is None
+    assert not os.path.exists(dst_path)
 
 
 def test_check_model_satellite_inputs_available(config_filename: str):

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -1,5 +1,4 @@
-import os
-import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd
@@ -7,7 +6,7 @@ import pytest
 import xarray as xr
 from ocf import dp
 
-from pvnet_app.app import run
+from pvnet_app.app import run_app
 from pvnet_app.models.registry import ModelSpec, get_model_specs
 from pvnet_app.save import fetch_locations
 from pvnet_app.settings import AppSettings
@@ -95,44 +94,42 @@ async def test_app(
     sat_5_data_zero_delay: xr.Dataset,
     cloudcasting_data: xr.Dataset,
     gsp_ids: list[int],
+    tmp_path: Path,
 ):
     """Test the app running the intraday models"""
 
     host, port = dp_host_and_port
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
+    # The app loads sat and NWP data from environment variable
+    # Save out data, and set paths as environmental variables
+    ukv_path = f"{tmp_path}/temp_nwp_ukv.zarr"
+    nwp_ukv_data.to_zarr(ukv_path)
 
-        # The app loads sat and NWP data from environment variable
-        # Save out data, and set paths as environmental variables
-        ukv_path = "temp_nwp_ukv.zarr"
-        nwp_ukv_data.to_zarr(ukv_path)
+    ecmwf_path = f"{tmp_path}/temp_nwp_ecmwf.zarr"
+    nwp_ecmwf_data.to_zarr(ecmwf_path)
 
-        ecmwf_path = "temp_nwp_ecmwf.zarr"
-        nwp_ecmwf_data.to_zarr(ecmwf_path)
+    cloudcasting_path = f"{tmp_path}/temp_cloudcasting.zarr"
+    cloudcasting_data.to_zarr(cloudcasting_path)
 
-        cloudcasting_path = "temp_cloudcasting.zarr"
-        cloudcasting_data.to_zarr(cloudcasting_path)
+    settings = AppSettings(
+        nwp_ukv_zarr_path=ukv_path,
+        nwp_ecmwf_zarr_path=ecmwf_path,
+        cloudcasting_zarr_path=cloudcasting_path,
+        # Satellite data will be mocked
+        satellite_icechunk_path_5="s3://fake/sat5",
+        run_critical_models_only=False,
+        forecast_validate_zig_zag_error_threshold=100000,
+        forecast_validate_sun_elevation_lower_limit=90,
+        data_platform_host=host,
+        data_platform_port=port,
+    )
 
-        settings = AppSettings(
-            nwp_ukv_zarr_path=ukv_path,
-            nwp_ecmwf_zarr_path=ecmwf_path,
-            cloudcasting_zarr_path=cloudcasting_path,
-            # Satellite data will be mocked
-            satellite_icechunk_path_5="s3://fake/sat5",
-            run_critical_models_only=False,
-            forecast_validate_zig_zag_error_threshold=100000,
-            forecast_validate_sun_elevation_lower_limit=90,
-            data_platform_host=host,
-            data_platform_port=port,
-        )
-
-        with patch(
-            "pvnet_app.data.satellite.open_satellite_data",
-            side_effect=[sat_5_data_zero_delay, None],
-        ):
-            # Run prediction
-            await run(settings=settings, t0=test_t0)
+    with patch(
+        "pvnet_app.data.satellite.open_satellite_data",
+        side_effect=[sat_5_data_zero_delay, None],
+    ):
+        # Run prediction
+        await run_app(settings=settings, t0=test_t0)
 
     model_specs = get_model_specs(get_critical_only=False)
     await check_number_of_forecasts(dp_client_with_locations, model_specs, test_t0, gsp_ids)
@@ -146,6 +143,7 @@ async def test_app_no_sat(
     nwp_ukv_data: xr.Dataset,
     nwp_ecmwf_data: xr.Dataset,
     gsp_ids: list[int],
+    tmp_path: Path,
 ):
     """Test the app for the case when no satellite data is available"""
 
@@ -155,31 +153,28 @@ async def test_app_no_sat(
     # different time than the previous test
     t0 = test_t0 - pd.Timedelta("30min")
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chdir(tmpdirname)
-        # The app loads sat and NWP data from environment variable
-        # Save out data, and set paths as environmental variables
-        ukv_path = "temp_nwp_ukv.zarr"
-        nwp_ukv_data.to_zarr(ukv_path)
+    # The app loads sat and NWP data from environment variable
+    # Save out data, and set paths as environmental variables
+    ukv_path = f"{tmp_path}/temp_nwp_ukv.zarr"
+    nwp_ukv_data.to_zarr(ukv_path)
 
-        ecmwf_path = "temp_nwp_ecmwf.zarr"
-        nwp_ecmwf_data.to_zarr(ecmwf_path)
+    ecmwf_path = f"{tmp_path}/temp_nwp_ecmwf.zarr"
+    nwp_ecmwf_data.to_zarr(ecmwf_path)
 
-        settings = AppSettings(
-            nwp_ukv_zarr_path=ukv_path,
-            nwp_ecmwf_zarr_path=ecmwf_path,
-            # Satellite data will be mocked as unavailable
-            satellite_icechunk_path_5="s3://fake/sat5",
-            run_critical_models_only=False,
-            forecast_validate_zig_zag_error_threshold=100000,
-            forecast_validate_sun_elevation_lower_limit=90,
-            data_platform_host=host,
-            data_platform_port=port,
-        )
+    settings = AppSettings(
+        nwp_ukv_zarr_path=ukv_path,
+        nwp_ecmwf_zarr_path=ecmwf_path,
+        # Satellite data will be mocked as unavailable
+        satellite_icechunk_path_5="s3://fake/sat5",
+        run_critical_models_only=False,
+        forecast_validate_zig_zag_error_threshold=100000,
+        forecast_validate_sun_elevation_lower_limit=90,
+        data_platform_host=host,
+        data_platform_port=port,
+    )
 
-
-        with patch("pvnet_app.data.satellite.open_satellite_data", return_value=None):
-            await run(settings=settings, t0=t0)
+    with patch("pvnet_app.data.satellite.open_satellite_data", return_value=None):
+        await run_app(settings=settings, t0=t0)
 
     # Only the models which don't use satellite will be run in this case
     model_specs = get_model_specs()

--- a/tests/integration/test_forecaster.py
+++ b/tests/integration/test_forecaster.py
@@ -18,6 +18,7 @@ def test_model_loading():
         forecaster = Forecaster(
             model_spec=model_spec,
             data_config_path="dummy.yaml",
+            run_data_dir="dummy_dir",
             t0=pd.Timestamp.now(),
             gsp_ids=[*range(10)],
             device=device,


### PR DESCRIPTION
# Pull Request

## Description

The current app saves everything to the current working directory at runtime. This is quite messy and quite brittle if for example you wanted to run multiple instances of the app at once locally. This PR refactors how the download paths are handled so that it defaults to use a temporary directory which is cleaned up when the app exists OR the path can be configured by the user and then the data is not cleaned up from that path. This should make it easier to debug the app locally.

I also slightly refactored the top-level functions

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
