### PR TITLE
Sanitise t0 inputs

### DIFF
--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -32,7 +32,7 @@ from pvnet_app.model_input_config import load_yaml_config
 from pvnet_app.models.registry import get_model_specs
 from pvnet_app.save import build_input_metadata, extract_location_capacities_mwp, fetch_locations
 from pvnet_app.settings import AppSettings
-from pvnet_app.utils import check_model_runs_finished, normalise_t0, save_batch_to_s3
+from pvnet_app.utils import check_model_runs_finished, resolve_t0, save_batch_to_s3
 from pvnet_app.validate_forecast import validate_forecast
 
 __version__ = version("pvnet-app")
@@ -84,7 +84,7 @@ async def run_app(
     sentry_sdk.set_tag("app_name", "pvnet_app")
     sentry_sdk.set_tag("version", __version__)
 
-    t0 = normalise_t0(t0)
+    t0 = resolve_t0(t0)
 
     logger.info(f"Using `pvnet` library version: {version('pvnet')}")
     logger.info(f"Using `pvnet_app` library version: {__version__}")

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import os
 import tempfile
+from datetime import datetime
 from importlib.metadata import version
 
 import pandas as pd
@@ -31,7 +32,7 @@ from pvnet_app.model_input_config import load_yaml_config
 from pvnet_app.models.registry import get_model_specs
 from pvnet_app.save import build_input_metadata, extract_location_capacities_mwp, fetch_locations
 from pvnet_app.settings import AppSettings
-from pvnet_app.utils import check_model_runs_finished, save_batch_to_s3
+from pvnet_app.utils import check_model_runs_finished, normalise_t0, save_batch_to_s3
 from pvnet_app.validate_forecast import validate_forecast
 
 __version__ = version("pvnet-app")
@@ -60,7 +61,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 async def run_app(
     settings: AppSettings,
-    t0: str | None = None,
+    t0: str | datetime | pd.Timestamp | None = None,
     write_predictions: bool = True,
 ) -> None | dict:
     """Set up the app environment and run a forecast.
@@ -70,8 +71,8 @@ async def run_app(
 
     Args:
         settings: The application settings
-        t0: The forecast init-time. If None, the current time is used. Floored
-            to the previous 30-minute mark and made naive-UTC before running
+        t0: The forecast init-time. If None, the current time is used. Input will be floored to the
+            previous 30-minutes.
         write_predictions: If True, write forecasts to the data platform. If
             False, skip the write and return the forecasters for local testing
     """
@@ -83,9 +84,7 @@ async def run_app(
     sentry_sdk.set_tag("app_name", "pvnet_app")
     sentry_sdk.set_tag("version", __version__)
 
-    # If inference datetime is None, set to now
-    t0 = pd.Timestamp.now(tz="UTC") if t0 is None else pd.Timestamp(t0).tz_localize("UTC")
-    t0 = t0.replace(tzinfo=None).floor("30min")
+    t0 = normalise_t0(t0)
 
     logger.info(f"Using `pvnet` library version: {version('pvnet')}")
     logger.info(f"Using `pvnet_app` library version: {__version__}")

--- a/src/pvnet_app/save.py
+++ b/src/pvnet_app/save.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import datetime
 
 import fsspec
 import numpy as np
@@ -14,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 DATAPLATFORM_MAX_VALUE = 1.09
+
+
+def to_data_platform_datetime(ts: pd.Timestamp) -> datetime:
+    """Converts internal naive UTC timestamp to aware UTC datetime."""
+    return ts.tz_localize("UTC").to_pydatetime()
+
 
 async def fetch_locations(
     client: dp.DataPlatformDataServiceStub,
@@ -257,7 +264,7 @@ def build_forecast_creation_request(
         forecaster=forecaster,
         location_uuid=location_uuid,
         energy_source=dp.EnergySource.SOLAR,
-        init_time_utc=init_time_utc.tz_localize("UTC").to_pydatetime(),
+        init_time_utc=to_data_platform_datetime(init_time_utc),
         values=forecast_value_requests,
         metadata=metadata,
     )
@@ -275,7 +282,7 @@ async def fetch_adjuster_values(
             dp.GetWeekAverageDeltasRequest(
                 location_uuid=location_uuid,
                 energy_source=dp.EnergySource.SOLAR,
-                pivot_timestamp_utc=init_time_utc.tz_localize("UTC").to_pydatetime(),
+                pivot_timestamp_utc=to_data_platform_datetime(init_time_utc),
                 forecaster=forecaster,
                 observer_name="pvlive_day_after",
             ),

--- a/src/pvnet_app/save.py
+++ b/src/pvnet_app/save.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 DATAPLATFORM_MAX_VALUE = 1.09
 
 
-def to_data_platform_datetime(ts: pd.Timestamp) -> datetime:
+def convert_to_utc_datetime(ts: pd.Timestamp) -> datetime:
     """Converts internal naive UTC timestamp to aware UTC datetime."""
     return ts.tz_localize("UTC").to_pydatetime()
 
@@ -264,7 +264,7 @@ def build_forecast_creation_request(
         forecaster=forecaster,
         location_uuid=location_uuid,
         energy_source=dp.EnergySource.SOLAR,
-        init_time_utc=to_data_platform_datetime(init_time_utc),
+        init_time_utc=convert_to_utc_datetime(init_time_utc),
         values=forecast_value_requests,
         metadata=metadata,
     )
@@ -282,7 +282,7 @@ async def fetch_adjuster_values(
             dp.GetWeekAverageDeltasRequest(
                 location_uuid=location_uuid,
                 energy_source=dp.EnergySource.SOLAR,
-                pivot_timestamp_utc=to_data_platform_datetime(init_time_utc),
+                pivot_timestamp_utc=convert_to_utc_datetime(init_time_utc),
                 forecaster=forecaster,
                 observer_name="pvlive_day_after",
             ),

--- a/src/pvnet_app/utils.py
+++ b/src/pvnet_app/utils.py
@@ -1,8 +1,10 @@
 """General utility functions for pvnet_app."""
 import logging
 import os
+from datetime import datetime
 
 import fsspec
+import pandas as pd
 import torch
 from ocf_data_sampler.numpy_sample.common_types import NumpyBatch
 
@@ -68,3 +70,17 @@ def check_model_runs_finished(
         raise Exception(
             f"{message}: {failed_forecasts}. Completed forecasts: {completed_forecasts}",
         )
+
+
+def normalise_t0(t0: str | datetime | pd.Timestamp | None) -> pd.Timestamp:
+    """Parse input t0 time to return a tz-naive timestamp representing UTC, floored to 30 minutes.
+
+    Args:
+        t0: The input timestamp. If None, the current time is used.
+    """
+    t0 = pd.Timestamp.now(tz="UTC") if t0 is None else pd.Timestamp(t0)
+
+    # If the input is timezone-aware, convert to UTC and then make it naive
+    if t0.tzinfo is not None:
+        t0 = t0.tz_convert("UTC").tz_localize(None)
+    return t0.floor("30min")

--- a/src/pvnet_app/utils.py
+++ b/src/pvnet_app/utils.py
@@ -72,8 +72,11 @@ def check_model_runs_finished(
         )
 
 
-def normalise_t0(t0: str | datetime | pd.Timestamp | None) -> pd.Timestamp:
-    """Parse input t0 time to return a tz-naive timestamp representing UTC, floored to 30 minutes.
+def resolve_t0(t0: str | datetime | pd.Timestamp | None) -> pd.Timestamp:
+    """Resolve any accepted t0 input to a timezone-naive UTC timestamp floored to 30 minutes.
+
+    Naive inputs are assumed to already be in UTC; timezone-aware inputs are converted to UTC before
+    the zone is dropped.
 
     Args:
         t0: The input timestamp. If None, the current time is used.


### PR DESCRIPTION
# Pull Request

## Description

This PR improves some of the init-time handling logic. Previously we were weak to the init-time input to `run_app()` being timezone aware. If a time like "2026-06-25 12:00Z" (which indicates the UTC timezone) were passed in, the app would crash.

We now use a couple of little helper functions to handle this and keep us consistent in manipulating timestamps

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
