### PR TITLE
Remove national=(sum of regionals) path

### DIFF
--- a/src/pvnet_app/data_platform.py
+++ b/src/pvnet_app/data_platform.py
@@ -16,8 +16,11 @@ from pvnet_app.utils import convert_to_utc_datetime
 
 logger = logging.getLogger(__name__)
 
-
+# Forecast values above this will be clipped before writing to the data-platform. Data-platform
+# currently only supports values up to this limit.
 DATAPLATFORM_MAX_VALUE = 1.09
+# Only allow these p-levels to be written to the data-platform
+ALLOWED_PLEVELS = ("p10", "p50", "p90")
 
 
 async def fetch_locations(
@@ -209,6 +212,31 @@ async def build_multi_forecast_creation_request(
     return forecast_requests
 
 
+def _build_forecast_value(
+    horizon_mins: int,
+    pvalues: np.ndarray,
+    plevels: list[str],
+    forecaster_name: str,
+    location_id: int,
+) -> dp.CreateForecastRequestForecastValue:
+    if (pvalues > DATAPLATFORM_MAX_VALUE).any():
+        high_plevels = np.array(plevels)[pvalues > DATAPLATFORM_MAX_VALUE].tolist()
+        logger.warning(
+            f"p-levels={high_plevels} exceed {DATAPLATFORM_MAX_VALUE} for model="
+            f"{forecaster_name}, location_id={location_id}, horizon_mins={horizon_mins}; "
+            f"clipping to {DATAPLATFORM_MAX_VALUE}",
+        )
+        pvalues = pvalues.clip(None, DATAPLATFORM_MAX_VALUE)
+
+    return dp.CreateForecastRequestForecastValue(
+        horizon_mins=horizon_mins,
+        p50_fraction=pvalues[plevels.index("p50")],
+        other_statistics_fractions={
+            k: v for k, v in zip(plevels, pvalues, strict=True) if k != "p50"
+        },
+    )
+
+
 def build_forecast_creation_request(
     da_forecast: xr.DataArray,
     forecaster: dp.Forecaster,
@@ -227,32 +255,23 @@ def build_forecast_creation_request(
     """
     location_id = int(da_forecast.location_id.values)
     horizons_mins = da_forecast.horizon_mins.values.tolist()
-    plevels = ["p10", "p50", "p90"]
 
+    # Filter the p-levels to the allowed set
+    plevels = [level for level in ALLOWED_PLEVELS if level in da_forecast.output_label.values]
     forecast_array = (
-        da_forecast.transpose("valid_times_utc", "output_label").sel(output_label=plevels)
+        da_forecast.sel(output_label=plevels).transpose("valid_times_utc", "output_label")
     ).values
 
-    forecast_value_requests = []
-    for h, row in zip(horizons_mins, forecast_array, strict=True):
-        if (row > DATAPLATFORM_MAX_VALUE).any():
-            high_plevels = np.array(plevels)[row > DATAPLATFORM_MAX_VALUE].tolist()
-            logger.warning(
-                f"p-levels={high_plevels} exceed {DATAPLATFORM_MAX_VALUE} for model="
-                f"{forecaster.forecaster_name}, location_id={location_id}, horizon_mins={h}; "
-                f"clipping to {DATAPLATFORM_MAX_VALUE}",
-            )
-            p10, p50, p90 = row.clip(None, DATAPLATFORM_MAX_VALUE)
-        else:
-            p10, p50, p90 = row
-
-        forecast_value_requests.append(
-            dp.CreateForecastRequestForecastValue(
-                horizon_mins=h,
-                p50_fraction=p50,
-                other_statistics_fractions={"p10": p10, "p90": p90},
-            ),
+    forecast_value_requests = [
+        _build_forecast_value(
+            horizon_mins=h,
+            pvalues=pvalues,
+            plevels=plevels,
+            forecaster_name=forecaster.forecaster_name,
+            location_id=location_id,
         )
+        for h, pvalues in zip(horizons_mins, forecast_array, strict=True)
+    ]
 
     return dp.CreateForecastRequest(
         forecaster=forecaster,

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -7,7 +7,7 @@ import pandas as pd
 import torch
 import xarray as xr
 import yaml
-from ocf_data_sampler.numpy_sample.common_types import NumpyBatch, TensorBatch
+from ocf_data_sampler.numpy_sample.common_types import NumpyBatch
 from ocf_data_sampler.torch_datasets.pvnet_dataset import PVNetConcurrentDataset
 from ocf_data_sampler.torch_datasets.utils.torch_batch_utils import (
     batch_to_tensor,
@@ -122,18 +122,18 @@ class PVNetForecaster:
         summation_commit: str | None,
         device: torch.device,
         hf_token: bool | str | None = None,
-    ) -> tuple[PVNetBaseModel, SummationBaseModel | None]:
-        """Load the GSP and summation models.
+    ) -> tuple[PVNetBaseModel, SummationBaseModel]:
+        """Load the regional and summation models.
 
         Args:
-            pvnet_repo: The huggingface repo of the GSP model
-            pvnet_commit: The commit hash of the GSP repo to load
+            pvnet_repo: The huggingface repo of the regional model
+            pvnet_commit: The commit hash of the regional model to load
             summation_repo: The huggingface repo of the summation model
             summation_commit: The commit hash of the summation model to load
             device: The device the models will be run on
             hf_token: HF authentication token.
         """
-        # Load the GSP level model
+        # Load the regional model
         model = PVNetBaseModel.from_pretrained(
             model_id=pvnet_repo,
             revision=pvnet_commit,
@@ -141,31 +141,28 @@ class PVNetForecaster:
         ).to(device)
 
         # Load the summation model
-        if summation_repo is None:
-            sum_model = None
-        else:
-            sum_model = SummationBaseModel.from_pretrained(
-                model_id=summation_repo,
-                revision=summation_commit,
-                token=hf_token,
-            ).to(device)
+        sum_model = SummationBaseModel.from_pretrained(
+            model_id=summation_repo,
+            revision=summation_commit,
+            token=hf_token,
+        ).to(device)
 
-            # Compare the current GSP model with the one the summation model was trained on
-            datamodule_path = SummationBaseModel.get_datamodule_config(
-                model_id=summation_repo,
-                revision=summation_commit,
-                token=hf_token,
+        # Compare the current GSP model with the one the summation model was trained on
+        datamodule_path = SummationBaseModel.get_datamodule_config(
+            model_id=summation_repo,
+            revision=summation_commit,
+            token=hf_token,
+        )
+        with open(datamodule_path) as cfg:
+            sum_pvnet_cfg = yaml.safe_load(cfg)["pvnet_model"]
+
+        sum_expected_gsp_model = (sum_pvnet_cfg["model_id"], sum_pvnet_cfg["revision"])
+        this_gsp_model = (pvnet_repo, pvnet_commit)
+
+        if sum_expected_gsp_model != this_gsp_model:
+            self.logger.warning(
+                _model_mismatch_msg.format(*this_gsp_model, *sum_expected_gsp_model),
             )
-            with open(datamodule_path) as cfg:
-                sum_pvnet_cfg = yaml.safe_load(cfg)["pvnet_model"]
-
-            sum_expected_gsp_model = (sum_pvnet_cfg["model_id"], sum_pvnet_cfg["revision"])
-            this_gsp_model = (pvnet_repo, pvnet_commit)
-
-            if sum_expected_gsp_model != this_gsp_model:
-                self.logger.warning(
-                    _model_mismatch_msg.format(*this_gsp_model, *sum_expected_gsp_model),
-                )
 
         return model, sum_model
 
@@ -192,27 +189,10 @@ class PVNetForecaster:
         self.logger.debug(f"GSPs: {location_ids}")
 
         relative_capacities = self.get_relative_capacities(location_ids.tolist())
-
         tensor_batch = copy_batch_to_device(batch_to_tensor(batch), self.device)
 
-        if self.summation_model is None:
-            self.logger.debug("Summing across GSPs to produce national forecast")
-            da_preds = self.predict_with_regional_sum(tensor_batch, relative_capacities)
-
-        else:
-            self.logger.debug("Using summation model to produce national forecast")
-            da_preds = self.predict_with_summation_model(tensor_batch, relative_capacities)
-
-        return da_preds
-
-    def predict_with_summation_model(
-        self,
-        batch: TensorBatch,
-        relative_capacities: np.ndarray,
-    ) -> xr.DataArray:
-        """Make predictions for the batch using regional and summation models."""
         # Make regional predictions using the GSP model
-        regional_preds = self.model(batch).detach().cpu().numpy()
+        regional_preds = self.model(tensor_batch).detach().cpu().numpy()
 
         # Make national predictions using summation model
         summation_batch = construct_sum_sample(
@@ -280,48 +260,6 @@ class PVNetForecaster:
 
         return xr.concat([da_national_preds, da_regional_preds], dim="location_id")
 
-    def predict_with_regional_sum(
-        self,
-        batch: TensorBatch,
-        relative_capacities: np.ndarray,
-    ) -> xr.DataArray:
-        """Make predictions for the batch using regional model and regional sum."""
-        # Make regional predictions using the GSP model
-        regional_preds = self.model(batch).detach().cpu().numpy()
-
-        location_ids = batch["location_id"].cpu().numpy().tolist()
-
-        da_regional_preds = preds_to_dataarray(
-            preds=regional_preds,
-            output_quantiles=self.model.output_quantiles,
-            location_ids=location_ids,
-            valid_times_utc=self.valid_times,
-            horizon_mins=self.horizon_mins,
-        )
-
-        # Make sundown masks so we can set predictions to zero when the sun is down
-        da_regional_sundown_mask, _ = self._make_sundown_masks(location_ids)
-
-        # Postprocess the regional predictions
-        da_regional_preds = (
-            # Set regional predictions to zero when sun is down
-            da_regional_preds.where(~da_regional_sundown_mask, other=0)
-            # Also clip negative predictions to zero
-            .clip(0, None)
-        )
-
-        # Make national predictions by summing the regional predictions weighted by the capacities
-        # The national predictions inherit the sundown masking and clipping from the regional
-        # predictions since they are derived from them
-        da_national_preds = (
-            (da_regional_preds * relative_capacities[:, None, None])
-            .sum(dim="location_id")
-            .expand_dims(dim="location_id", axis=0)
-            .assign_coords(location_id=[0])
-        )
-
-        return xr.concat([da_national_preds, da_regional_preds], dim="location_id")
-
     def _make_sundown_masks(self, location_ids: list[int]) -> tuple[xr.DataArray, xr.DataArray]:
         """Make a sundown mask for all locations and valid times."""
         elevations = []
@@ -346,7 +284,7 @@ class PVNetForecaster:
             },
         )
 
-        # All GSPs must be masked to mask national
+        # All regions must be masked to mask national
         da_national_sundown_mask = da_regional_sundown_mask.all(dim="location_id")
 
         return da_regional_sundown_mask, da_national_sundown_mask

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -34,7 +34,7 @@ def model_uses_satellite_data(model_spec: ModelSpec, hf_token: str) -> bool:
 async def check_number_of_forecasts(
     client: dp.DataPlatformDataServiceStub,
     model_specs: list[ModelSpec],
-    test_t0: pd.Timestamp,
+    t0: pd.Timestamp,
     expected_location_ids: list[int],
 ) -> None:
     """Check that the expected number of forecasts have been saved to the Data Platform."""
@@ -46,7 +46,7 @@ async def check_number_of_forecasts(
         model_name = model_spec.name.replace("-", "_")
         model_adjust = f"{model_name}_adjust"
         expected_valid_times = pd.date_range(
-            test_t0 + pd.Timedelta("30min"),
+            t0 + pd.Timedelta("30min"),
             periods=(72 if model_spec.is_day_ahead else 16),
             freq="30min",
             tz="UTC",
@@ -77,7 +77,7 @@ async def check_number_of_forecasts(
                         energy_source=dp.EnergySource.SOLAR,
                         location_uuid=locations_dict[0].location_uuid,
                         forecaster=forecasters_by_name[forecaster_name],
-                        initialization_timestamp_utc=test_t0.tz_localize("UTC").to_pydatetime(),
+                        initialization_timestamp_utc=t0.tz_localize("UTC").to_pydatetime(),
                         # Set wide time window to make sure there aren't any values outside the
                         # expected valid times
                         time_window=dp.TimeWindow(
@@ -168,7 +168,7 @@ async def test_app_no_sat(
 
     host, port = dp_host_and_port
 
-    # Change the init time to be 30 minutes later than the test_t0, so that the forecasts are for a
+    # Change the init time to be 30 minutes before the test_t0, so that the forecasts are for a
     # different time than the previous test
     t0 = test_t0 - pd.Timedelta("30min")
 

--- a/tests/integration/test_forecaster.py
+++ b/tests/integration/test_forecaster.py
@@ -25,8 +25,4 @@ def test_model_loading():
 
         # Verify models loaded correctly
         assert isinstance(forecaster.model, PVNetBaseModel)
-
-        if model_spec.summation.repo is None:
-            assert forecaster.summation_model is None
-        else:
-            assert isinstance(forecaster.summation_model, SummationBaseModel)
+        assert isinstance(forecaster.summation_model, SummationBaseModel)


### PR DESCRIPTION
# Pull Request

## Description

This removes the code path to use the regional sum as the national prediction. We have not used this codepath in a long time and have no plans to do so. Plus that code-path is broken in a few ways already

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
