### PR TITLE
Improve global variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Just before the batch goes into the ML models, we check that:
 ### Forecast checks
 
 After the ML models have run, we check the national forecast only:
-- It does not exceed 110% of the national capacity. The forecast fails validation if any
+- It does not exceed 100% of the national capacity. The forecast fails validation if any
   value is above this.
 - It does not exceed an absolute ceiling of 20 GW. The forecast fails validation if any
   value is above this.

--- a/scripts/update_readme_table.py
+++ b/scripts/update_readme_table.py
@@ -12,7 +12,7 @@ from pvnet_app.model_input_config import load_yaml_config
 from pvnet_app.models.registry import HuggingFaceCommit, get_model_specs
 
 
-def make_huffingface_link(model_commit: HuggingFaceCommit) -> str:
+def make_huggingface_link(model_commit: HuggingFaceCommit) -> str:
     """Make a link to the model on huggingface.
 
     Args:
@@ -22,7 +22,7 @@ def make_huffingface_link(model_commit: HuggingFaceCommit) -> str:
 
 
 def generate_table() -> str:
-    """Make a new summary table for the models descriobed in the model configs."""
+    """Make a new summary table for the models described in the model configs."""
     model_specs = get_model_specs()
     columns = [
         "Model Name",
@@ -41,8 +41,8 @@ def generate_table() -> str:
 
 
     for model_spec in model_specs:
-        pvnet_link = make_huffingface_link(model_spec.pvnet)
-        summation_link = make_huffingface_link(model_spec.summation)
+        pvnet_link = make_huggingface_link(model_spec.pvnet)
+        summation_link = make_huggingface_link(model_spec.summation)
 
         data_config_path = PVNetBaseModel.get_data_config(
             model_spec.pvnet.repo,

--- a/src/pvnet_app/adjuster.py
+++ b/src/pvnet_app/adjuster.py
@@ -57,7 +57,7 @@ def apply_adjuster_values(
     absolute_limit = ADJUSTER_LIMIT_ABSOLUTE_WATTS / effective_capacity_watts
     adjuster_values_array = np.clip(adjuster_values_array, -absolute_limit, absolute_limit)
 
-    # Apply fraction limit to the ajusterr
+    # Apply fraction limit to the adjuster
     fraction_limit = da_forecast.sel(output_label="p50").values * ADJUSTER_LIMIT_FORECAST_FRACTION
     adjuster_values_array = np.clip(adjuster_values_array, -fraction_limit, fraction_limit)
 

--- a/src/pvnet_app/adjuster.py
+++ b/src/pvnet_app/adjuster.py
@@ -11,6 +11,12 @@ from pvnet_app.utils import convert_to_utc_datetime
 
 logger = logging.getLogger(__name__)
 
+# Limit adjuster so it doesn't change the forecast by more than this amount in watts
+ADJUSTER_LIMIT_ABSOLUTE_WATTS: float = 1e9
+
+# Limit adjuster so it doesn't change the forecast by more than this fraction of the forecast value
+ADJUSTER_LIMIT_FORECAST_FRACTION: float = 0.1
+
 
 async def fetch_adjuster_values(
     client: dp.DataPlatformDataServiceStub,
@@ -47,13 +53,13 @@ def apply_adjuster_values(
         else:
             logger.warning(f"No adjuster value found for horizon_mins={h}; using 0.0 as default")
 
-    # Limit adjuster values to be no more than 1 GW
-    frac_1gw = 1e9 / effective_capacity_watts
-    adjuster_values_array = np.clip(adjuster_values_array, -frac_1gw, frac_1gw)
+    # Apply absolute limit to the adjuster
+    absolute_limit = ADJUSTER_LIMIT_ABSOLUTE_WATTS / effective_capacity_watts
+    adjuster_values_array = np.clip(adjuster_values_array, -absolute_limit, absolute_limit)
 
-    # Limit adjuster values to be no more than 10% of the forecast value
-    frac_10pc = da_forecast.sel(output_label="p50").values * 0.1
-    adjuster_values_array = np.clip(adjuster_values_array, -frac_10pc, frac_10pc)
+    # Apply fraction limit to the ajusterr
+    fraction_limit = da_forecast.sel(output_label="p50").values * ADJUSTER_LIMIT_FORECAST_FRACTION
+    adjuster_values_array = np.clip(adjuster_values_array, -fraction_limit, fraction_limit)
 
     da_adjuster_values = xr.DataArray(
         data=adjuster_values_array,
@@ -63,7 +69,7 @@ def apply_adjuster_values(
 
     # Adjuster values are the average of (forecast - observed) so we need to subtract
     # Also force the adjusted forecast to be positive by clipping at 0.0
-    da_adjusted_forecast = (da_forecast - da_adjuster_values).clip(0, 1)
+    da_adjusted_forecast = (da_forecast - da_adjuster_values).clip(0, None)
 
     return da_adjusted_forecast
 

--- a/src/pvnet_app/consts.py
+++ b/src/pvnet_app/consts.py
@@ -1,9 +1,9 @@
 """Constants."""
 
-sat_path = "sat.zarr"
-nwp_ukv_path = "nwp_ukv.zarr"
-nwp_ecmwf_path = "nwp_ecmwf.zarr"
-nwp_cloudcasting_path = "nwp_cloudcasting.zarr"
-generation_path = "generation.zarr"
+sat_path: str = "sat.zarr"
+nwp_ukv_path: str = "nwp_ukv.zarr"
+nwp_ecmwf_path: str = "nwp_ecmwf.zarr"
+nwp_cloudcasting_path: str = "nwp_cloudcasting.zarr"
+generation_path: str = "generation.zarr"
 
-forecast_version = "2.8.0"
+forecast_version: str = "2.8.0"

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -86,7 +86,7 @@ def interpolate_missing_satellite_timestamps(ds: xr.Dataset, max_gap: pd.Timedel
 
     The max gap is inclusive of timestamps either side. E.g. if max gap is 15 minutes and the
     satellite includes timestamps 12:00 and 12:15, then 12:05 and 12:10 will be filled. If the max
-    gap was 10 minutes, then none of the timestamps would be filled. A max gap if 5 minutes will do
+    gap was 10 minutes, then none of the timestamps would be filled. A max gap of 5 minutes will do
     nothing since the normal spacing is already 5 minutes.
 
     Args:

--- a/src/pvnet_app/data_platform.py
+++ b/src/pvnet_app/data_platform.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 # Forecast values above this will be clipped before writing to the data-platform. Data-platform
 # currently only supports values up to this limit.
-DATAPLATFORM_MAX_VALUE = 1.09
+DATAPLATFORM_MAX_VALUE: float = 1.09
 # Only allow these p-levels to be written to the data-platform
-ALLOWED_PLEVELS = ("p10", "p50", "p90")
+ALLOWED_PLEVELS: tuple[str, ...] = ("p10", "p50", "p90")
 
 
 async def fetch_locations(

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -23,7 +23,7 @@ from pvnet_app.model_input_config import modify_data_config_for_production
 from pvnet_app.models.registry import ModelSpec
 
 # If the solar elevation (in degrees) is less than this the predictions are set to zero
-MIN_DAY_ELEVATION_DEGREES = 0
+MIN_DAY_ELEVATION_DEGREES: float = 0.0
 
 
 _model_mismatch_msg = (
@@ -40,6 +40,8 @@ def preds_to_dataarray(
     output_quantiles: list[float] | None,
     valid_times_utc: pd.DatetimeIndex,
     horizon_mins: np.ndarray,
+    longitudes: np.ndarray,
+    latitudes: np.ndarray,
 ) -> xr.DataArray:
     """Put numpy array of predictions into a dataarray."""
     if output_quantiles is not None:
@@ -56,6 +58,8 @@ def preds_to_dataarray(
             "output_label": output_labels,
             "valid_times_utc": valid_times_utc,
             "horizon_mins": ("valid_times_utc", horizon_mins),
+            "longitude": ("location_id", longitudes),
+            "latitude": ("location_id", latitudes),
         },
     )
 
@@ -221,6 +225,9 @@ class PVNetForecaster:
         )
 
         location_ids = batch["location_id"].cpu().numpy().tolist()
+        longitudes, latitudes = self.location_coords.loc[
+            location_ids, ["longitude", "latitude"]
+        ].T.values
 
         # Convert regional and national predictions to DataArrays separately since they may have
         # different output quantiles. We will concatenate them later after all the processing is
@@ -231,14 +238,19 @@ class PVNetForecaster:
             location_ids=location_ids,
             valid_times_utc=self.valid_times,
             horizon_mins=self.horizon_mins,
+            longitudes=longitudes,
+            latitudes=latitudes,
         )
 
+        longitude, latitude = self.location_coords.loc[0, ["longitude", "latitude"]].values
         da_national_preds = preds_to_dataarray(
             preds=normed_national[np.newaxis],
             output_quantiles=self.summation_model.output_quantiles,
             location_ids=[0],
             valid_times_utc=self.valid_times,
             horizon_mins=self.horizon_mins,
+            longitudes=[longitude],
+            latitudes=[latitude],
         )
 
         # Make sundown masks so we can set predictions to zero when the sun is down

--- a/src/pvnet_app/validate_forecast.py
+++ b/src/pvnet_app/validate_forecast.py
@@ -79,10 +79,12 @@ def check_forecast_fluctuations(
 
     def zig_zag_over_threshold(threshold: float) -> bool:
         return (
-            (diff[0:-2] > threshold)  # forecast goes up
-            & (diff[1:-1] < -threshold)  # goes down
-            & (diff[2:] > threshold)  # goes up
-        ).any()
+            (
+                (diff[0:-2] > threshold)  # forecast goes up
+                & (diff[1:-1] < -threshold)  # goes down
+                & (diff[2:] > threshold)  # goes up
+            ).any()
+        )
 
     has_large_jumps = zig_zag_over_threshold(warning_threshold_mw)
     has_critical_jumps = zig_zag_over_threshold(error_threshold_mw)

--- a/src/pvnet_app/validate_forecast.py
+++ b/src/pvnet_app/validate_forecast.py
@@ -3,27 +3,24 @@
 import logging
 
 import numpy as np
-import pandas as pd
 import pvlib
 import xarray as xr
 
 logger = logging.getLogger(__name__)
 
-# A forecast is bad if above this fraction of national capacity
-RELATIVE_MAX_FORECAST = 1.1
+# A forecast fails validation if the national forecast is above this fraction of capacity
+# The GSP forecasts are not checked on this criteria since a few regions can have generations
+# significantly above the capacity
+NATIONAL_RELATIVE_MAX_FORECAST: float = 1.0
 
-# A forecast is bad if above this absolute value
-# Note: The all time peak generation as of 2025-04-27 was ~15.4 GW
-#  - See https://www.solar.sheffield.ac.uk/pvlive/
-ABSOLUTE_MAX_FORECAST = 20_000
-
-# The UK's longitude and latitude - used for solar position calculations
-UK_LONGITUDE = -3.4360
-UK_LATITUDE = 55.3781
+# A forecast fails validation if the national forecast is above this absolute value in MW
+# Note: The all time peak generation as of 2026-07-06 was ~16.3 GW
+#       See https://www.solar.sheffield.ac.uk/pvlive/
+NATIONAL_ABSOLUTE_MAX_FORECAST_MW: int = 20_000
 
 
 def check_forecast_max(
-    national_forecast_mw: pd.Series,
+    national_forecast_mw: xr.DataArray,
     national_capacity_mw: float,
     model_name: str,
 ) -> bool:
@@ -33,28 +30,28 @@ def check_forecast_max(
     - Check the forecast doesn't exceed some arbitrary limit.
 
     Args:
-        national_forecast_mw: The forecast values for the nation (in MW)
+        national_forecast_mw: The national forecast values (in MW)
         national_capacity_mw: The national PV capacity (in MW)
         model_name: The name of the model that generated the forecast
     """
     forecast_okay = True
 
-    # Compute the maximum from the entire forecast array
     max_forecast_mw = national_forecast_mw.values.max()
 
-    # Check it doesn't exceed the national capacity
+    # Check forecast doesn't exceed relative limit of the national capacity
     max_forecast_frac = max_forecast_mw / national_capacity_mw
-    if max_forecast_frac > RELATIVE_MAX_FORECAST:
+    if max_forecast_frac > NATIONAL_RELATIVE_MAX_FORECAST:
         logger.warning(
             f"{model_name}: The maximum of the national forecast is {max_forecast_mw} which is "
             f"{max_forecast_frac:.2%} of the national capacity ({national_capacity_mw}MW).",
         )
         forecast_okay = False
 
-    if max_forecast_mw > ABSOLUTE_MAX_FORECAST:
+    # Check forecast doesn't exceed absolute limit
+    if max_forecast_mw > NATIONAL_ABSOLUTE_MAX_FORECAST_MW:
         logger.warning(
-            f"{model_name}: National forecast exceeds {ABSOLUTE_MAX_FORECAST / 1e3:.2f} GW. "
-            f"Max forecast value is {max_forecast_mw / 1e3:.2f} GW).",
+            f"{model_name}: The maximum of the national forecast is {max_forecast_mw} which "
+            f"exceeds the limit of {NATIONAL_ABSOLUTE_MAX_FORECAST_MW} MW."
         )
         forecast_okay = False
 
@@ -62,7 +59,7 @@ def check_forecast_max(
 
 
 def check_forecast_fluctuations(
-    national_forecast_mw: pd.Series,
+    national_forecast_mw: xr.DataArray,
     warning_threshold_mw: float,
     error_threshold_mw: float,
     model_name: str,
@@ -82,12 +79,10 @@ def check_forecast_fluctuations(
 
     def zig_zag_over_threshold(threshold: float) -> bool:
         return (
-            (
-                (diff[0:-2] > threshold)  # forecast goes up
-                & (diff[1:-1] < -threshold)  # goes down
-                & (diff[2:] > threshold)  # goes up
-            ).any()
-        )
+            (diff[0:-2] > threshold)  # forecast goes up
+            & (diff[1:-1] < -threshold)  # goes down
+            & (diff[2:] > threshold)  # goes up
+        ).any()
 
     has_large_jumps = zig_zag_over_threshold(warning_threshold_mw)
     has_critical_jumps = zig_zag_over_threshold(error_threshold_mw)
@@ -104,34 +99,36 @@ def check_forecast_fluctuations(
 
 
 def check_forecast_positive_during_daylight(
-    national_forecast_mw: pd.Series,
+    national_forecast_mw: xr.DataArray,
     sun_elevation_lower_limit: float,
     model_name: str,
 ) -> bool:
     """Check that the forecast values are positive when the sun is up.
 
     Args:
-        national_forecast_mw: The forecast values for the nation (in MW)
+        national_forecast_mw: The national forecast values (in MW)
         sun_elevation_lower_limit: The lower limit for the sun elevation (in degrees)
         model_name: The name of the model that generated the forecast
     """
     # Calculate the solar position throughout the forecast
-    solpos = pvlib.solarposition.get_solarposition(
-        time=national_forecast_mw.index,  # The index is expect to be the valid times
-        longitude=UK_LONGITUDE,
-        latitude=UK_LATITUDE,
+    solar_elevation = pvlib.solarposition.get_solarposition(
+        time=national_forecast_mw["valid_times_utc"].values,
+        longitude=national_forecast_mw["longitude"].item(),
+        latitude=national_forecast_mw["latitude"].item(),
         method="nrel_numpy",
-    )
+    )["elevation"].values
 
     # Check if forecast values are > 0 when sun elevation is over the threshold
-    is_daylight = solpos["elevation"] > sun_elevation_lower_limit
-    bad_times = national_forecast_mw[is_daylight & (national_forecast_mw <= 0)]
+    is_daylight_and_zero = (solar_elevation > sun_elevation_lower_limit) & (
+        national_forecast_mw.values <= 0
+    )
 
-    if (num_bad_times := len(bad_times)) > 0:
+    if is_daylight_and_zero.sum().item() > 0:
+        offending_times = national_forecast_mw["valid_times_utc"].values[is_daylight_and_zero]
         logger.warning(
             f"{model_name}: Forecast values must be > 0 when sun elevation > "
             f"{sun_elevation_lower_limit} degrees. "
-            f"Found {num_bad_times} offending timestamps: {bad_times.index.tolist()}",
+            f"Found {len(offending_times)} offending timestamps: {offending_times}",
         )
         return False
     else:
@@ -164,9 +161,7 @@ def validate_forecast(
     """
     # Compute the national forecast in MW from the normalised forecast
     # Validation is only performed on the national forecast
-    national_forecast_mw = (
-        da_forecast.sel(location_id=0, output_label="p50").to_series() * national_capacity_mw
-    )
+    national_forecast_mw = da_forecast.sel(location_id=0, output_label="p50") * national_capacity_mw
 
     forecast_max_okay = check_forecast_max(
         national_forecast_mw=national_forecast_mw,

--- a/tests/test_validate_forecast.py
+++ b/tests/test_validate_forecast.py
@@ -18,11 +18,14 @@ def make_forecast_dataarray(
 ) -> xr.DataArray:
     """Helper function to create a forecast DataArray for testing purposes."""
     return xr.DataArray(
-        np.array(forecast_values)[None, :, None],  # MW
+        np.array(forecast_values)[None, :, None],
         coords={
             "location_id": [0],
             "valid_times_utc": valid_times,
             "output_label": ["p50"],
+            # Set some dummy coordinates for the location of roughly the UK
+            "longitude": ("location_id", [-3]),
+            "latitude": ("location_id", [55]),
         },
         dims=["location_id", "valid_times_utc", "output_label"],
     )
@@ -42,7 +45,7 @@ def test_validate_forecast_ok():
         valid_times=pd.date_range("2025-01-01 00:00", periods=3, freq="30min"),
     )
 
-    national_forecast_mw = da_forecast_mw.sel(location_id=0, output_label="p50").to_series()
+    national_forecast_mw = da_forecast_mw.sel(location_id=0, output_label="p50")
 
     assert check_forecast_max(
         national_forecast_mw=national_forecast_mw,
@@ -74,7 +77,7 @@ def test_validate_forecast_ok():
 
 
 def test_validate_forecast_above_110percent():
-    """Test that validate_forecast returns False when forecast is above 110% of capacity"""
+    """Test that validate_forecast returns False when forecast is above 100% of capacity"""
 
     da_forecast = make_forecast_dataarray(
         forecast_values=[1.2],


### PR DESCRIPTION
# Pull Request

## Description

Improve the use of global variables across the library. In lots of places we have magic numbers scattered through the code and we have lots of different clipping schemes going on. This PR improves these things 

- Add type hints and better comments to explain current global variables
- Extract some magic numbers to global variables
- Change the global variable for validating the national forecast from 110% of capacity to 100%. National is never above 100% and this would be a real error
- Remove upper clipping of the adjuster so that it matches the clipping of the unadjusted forecast

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
