### PR TITLE
Download satellite according to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ The app is configured at runtime with many environmental variables. See [setting
 <!-- START model-config-table -->
 | Model Name | Uses satellite | Uses UKV | Uses ECMWF | Uses cloudcasting | PVNet Hugging Face Link | PVNet Summation Hugging Face Link |
 | ----|----|----|----|----|----|---- |
+| pvnet_v2 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/0f6a00de0c6a12b36f6c050ba7d9916949803ad8) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/f5b6b7fab06d762e900f6caeb3ec6af07db3ec4c) |
 | pvnet_intra_allbells30 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/b88eae46dd40d8670de00b0c0e64d6363886aadf) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/b10af61ef303566dee6647f0b9eba07432d91957) |
-| pvnet_intra_allbells0 | yes | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/0f6a00de0c6a12b36f6c050ba7d9916949803ad8) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/f5b6b7fab06d762e900f6caeb3ec6af07db3ec4c) |
-| pvnet_da_ecmwf | - | - | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/bd376303f753dd869dd0fd194906451b91b2dcd1) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/2e301b599ab8a15ed02d09aceea43c7f7c6f4516) |
-| pvnet_intra_sat30 | yes | - | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/14f2223681c9741163a3099493d97bcd1c4e0025) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/ac6d5dc380628f15ad02c53a2ddb8727e1e2907e) |
-| pvnet_da_ukv | - | yes | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/b242aad4ed243efe4e701b9ae61136615795faa8) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/2263afba597d231c0699782b9e44c7208a751345) |
-| pvnet_da_2nwp | - | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/723603423d1b2b74fe49715a2d52fa7593a9451e) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/fe1c826c4141d8cefc5c5b60618ad1654a06f9b0) |
+| pvnet_ecmwf | - | - | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/bd376303f753dd869dd0fd194906451b91b2dcd1) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/2e301b599ab8a15ed02d09aceea43c7f7c6f4516) |
+| pvnet_sat_only | yes | - | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/14f2223681c9741163a3099493d97bcd1c4e0025) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/ac6d5dc380628f15ad02c53a2ddb8727e1e2907e) |
+| pvnet_ukv_only | - | yes | - | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/b242aad4ed243efe4e701b9ae61136615795faa8) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/2263afba597d231c0699782b9e44c7208a751345) |
+| pvnet_day_ahead | - | yes | yes | - | [HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_region/tree/723603423d1b2b74fe49715a2d52fa7593a9451e) | [Summation HF Link](https://huggingface.co/openclimatefix-models/pvnet_uk_summation/tree/fe1c826c4141d8cefc5c5b60618ad1654a06f9b0) |
 
 <!-- END model-config-table -->
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -34,7 +34,7 @@ from pvnet_app.data_platform import (
 from pvnet_app.forecaster import PVNetForecaster
 from pvnet_app.model_input_config import (
     fetch_model_data_config_paths,
-    get_earliest_satellite_start_interval_minutes,
+    get_earliest_satellite_interval_start_minutes,
     get_maximum_satellite_spatial_window_size,
     get_required_nwp_providers,
     load_yaml_config,
@@ -170,7 +170,7 @@ async def _run_forecast_pipeline(
         logger.info("Downloading satellite data")
 
         # Only download and check the satellite data which is required by the models
-        start_interval_minutes = get_earliest_satellite_start_interval_minutes(data_configs)
+        interval_start_minutes = get_earliest_satellite_interval_start_minutes(data_configs)
         window_size = get_maximum_satellite_spatial_window_size(data_configs)
 
         sat_downloader = SatelliteDownloader(
@@ -179,7 +179,7 @@ async def _run_forecast_pipeline(
             source_path_15=settings.satellite_icechunk_path_15,
             s3_region=settings.satellite_s3_region,
             destination_path=f"{scratch_dir}/{sat_path}",
-            start_interval_minutes=start_interval_minutes,
+            interval_start_minutes=interval_start_minutes,
             window_size_pixels=window_size,
         )
         sat_downloader.run()

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -34,8 +34,8 @@ from pvnet_app.data_platform import (
 from pvnet_app.forecaster import PVNetForecaster
 from pvnet_app.model_input_config import (
     fetch_model_data_config_paths,
-    get_maximum_satellite_spatial_window_size,
     get_earliest_satellite_start_interval_minutes,
+    get_maximum_satellite_spatial_window_size,
     get_required_nwp_providers,
     load_yaml_config,
 )

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -34,6 +34,8 @@ from pvnet_app.data_platform import (
 from pvnet_app.forecaster import PVNetForecaster
 from pvnet_app.model_input_config import (
     fetch_model_data_config_paths,
+    get_maximum_satellite_spatial_window_size,
+    get_earliest_satellite_start_interval_minutes,
     get_required_nwp_providers,
     load_yaml_config,
 )
@@ -167,12 +169,18 @@ async def _run_forecast_pipeline(
     if any("satellite" in conf["input_data"] for conf in data_configs):
         logger.info("Downloading satellite data")
 
+        # Only download and check the satellite data which is required by the models
+        start_interval_minutes = get_earliest_satellite_start_interval_minutes(data_configs)
+        window_size = get_maximum_satellite_spatial_window_size(data_configs)
+
         sat_downloader = SatelliteDownloader(
             t0=t0,
             source_path_5=settings.satellite_icechunk_path_5,
             source_path_15=settings.satellite_icechunk_path_15,
             s3_region=settings.satellite_s3_region,
             destination_path=f"{scratch_dir}/{sat_path}",
+            start_interval_minutes=start_interval_minutes,
+            window_size_pixels=window_size,
         )
         sat_downloader.run()
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -317,7 +317,7 @@ async def _run_forecast_pipeline(
             forecasts=forecasts,
             locations=locations,
             t0=t0,
-            input_s3_paths={
+            input_paths={
                 "nwp_ecmwf": settings.nwp_ecmwf_zarr_path,
                 "nwp_ukv": settings.nwp_ukv_zarr_path,
                 "satellite": settings.satellite_icechunk_path_5,

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -250,8 +250,8 @@ def check_model_satellite_inputs_available(
 
 def get_pvnet_satellite_spatial_bounds(
     ds: xr.Dataset,
-    width_pixels: int = 24,
-    height_pixels: int = 24,
+    width_pixels: int,
+    height_pixels: int,
 ) -> xr.Dataset:
     """Get the spatial extent of the satellite data used in PVNet.
 
@@ -329,19 +329,21 @@ class SatelliteDownloader:
         source_path_15: str | None,
         s3_region: str,
         destination_path: str,
+        start_interval_minutes: int,
+        window_size_pixels: int,
     ) -> None:
         """Class to download and process satellite data."""
         self.t0 = t0
         self.source_path_5 = source_path_5
         self.source_path_15 = source_path_15
         self.s3_region = s3_region
-        self.time_window = pd.Timedelta("1h")
+        self.destination_path = destination_path
+        self.start_interval = pd.Timedelta(f"{start_interval_minutes}min")
+        self.window_size_pixels = window_size_pixels
         self.valid_times = None
         self.sat_choice = None
-        self.destination_path = destination_path
 
-    @staticmethod
-    def data_is_okay(ds: xr.Dataset) -> bool:
+    def data_is_okay(self, ds: xr.Dataset) -> bool:
         """Apply quality checks to the satellite data.
 
         Args:
@@ -351,7 +353,11 @@ class SatelliteDownloader:
             bool: Whether the data passes the quality checks
         """
         # Slice the data to the spatial extent used in PVNet
-        ds = get_pvnet_satellite_spatial_bounds(ds)
+        ds = get_pvnet_satellite_spatial_bounds(
+            ds, 
+            width_pixels=self.window_size_pixels, 
+            height_pixels=self.window_size_pixels,
+        )
 
         too_many_nans = contains_too_many_of_value(ds, value=np.nan, threshold=0.05)
 

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -45,7 +45,7 @@ def open_satellite_data(s3_icechunk_path: str, region: str) -> xr.Dataset | None
     return ds
 
 
-def fill_1d_bool_gaps(x: np.array, max_gap: int) -> np.array:
+def fill_1d_bool_gaps(x: np.ndarray, max_gap: int) -> np.ndarray:
     """Fill consecutive False elements if their number is less than the gap_size.
 
     Args:
@@ -440,6 +440,10 @@ class SatelliteDownloader:
             .sel(time=slice(self.t0 - self.time_window, self.t0))
             .load()
         )
+
+        if len(ds.time) == 0:
+            logger.warning("No satellite data available in recent window.")
+            return
 
         if self.data_is_okay(ds):
             ds = self.process(ds)

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -329,7 +329,7 @@ class SatelliteDownloader:
         source_path_15: str | None,
         s3_region: str,
         destination_path: str,
-        start_interval_minutes: int,
+        interval_start_minutes: int,
         window_size_pixels: int,
     ) -> None:
         """Class to download and process satellite data."""
@@ -338,7 +338,7 @@ class SatelliteDownloader:
         self.source_path_15 = source_path_15
         self.s3_region = s3_region
         self.destination_path = destination_path
-        self.start_interval = pd.Timedelta(f"{start_interval_minutes}min")
+        self.start_interval = pd.Timedelta(f"{interval_start_minutes}min")
         self.window_size_pixels = window_size_pixels
         self.valid_times = None
         self.sat_choice = None
@@ -443,7 +443,7 @@ class SatelliteDownloader:
             ds_dict[best_source]
             .sortby("time")
             .drop_duplicates("time", keep="last")
-            .sel(time=slice(self.t0 - self.time_window, self.t0))
+            .sel(time=slice(self.t0 + self.start_interval, self.t0))
             .load()
         )
 

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -354,8 +354,8 @@ class SatelliteDownloader:
         """
         # Slice the data to the spatial extent used in PVNet
         ds = get_pvnet_satellite_spatial_bounds(
-            ds, 
-            width_pixels=self.window_size_pixels, 
+            ds,
+            width_pixels=self.window_size_pixels,
             height_pixels=self.window_size_pixels,
         )
 

--- a/src/pvnet_app/data_platform.py
+++ b/src/pvnet_app/data_platform.py
@@ -133,9 +133,9 @@ async def build_input_metadata(
 
     # Add timestamp when the NWP and satellite were last updated
     for name, path in input_paths.items():
-        fs = fsspec.open(path).fs
         if path is not None:
             try:
+                fs = fsspec.open(path).fs
                 if path.endswith(".zarr"):
                     modified_date = fs.modified(f"{path}/.zattrs")
                 elif path.endswith(".icechunk"):

--- a/src/pvnet_app/data_platform.py
+++ b/src/pvnet_app/data_platform.py
@@ -109,7 +109,7 @@ async def fetch_or_create_forecaster(
 async def build_input_metadata(
     client: dp.DataPlatformDataServiceStub,
     location_uuid: str,
-    input_s3_paths: dict[str, str],
+    input_paths: dict[str, str],
     app_version: str,
 ) -> Struct:
     """Get metadata for the forecast."""
@@ -132,17 +132,16 @@ async def build_input_metadata(
         )
 
     # Add timestamp when the NWP and satellite were last updated
-    fs = fsspec.filesystem("s3", anon=False)
-
-    for name, s3_path in input_s3_paths.items():
-        if s3_path is not None:
+    for name, path in input_paths.items():
+        fs = fsspec.open(path).fs
+        if path is not None:
             try:
-                if s3_path.endswith(".zarr"):
-                    modified_date = fs.modified(f"{s3_path}/.zattrs")
-                elif s3_path.endswith(".icechunk"):
-                    modified_date = fs.modified(f"{s3_path}/refs/branch.main")
+                if path.endswith(".zarr"):
+                    modified_date = fs.modified(f"{path}/.zattrs")
+                elif path.endswith(".icechunk"):
+                    modified_date = fs.modified(f"{path}/refs/branch.main")
                 else:
-                    logger.warning(f"Unknown file type for {name}: {s3_path}; skipping")
+                    logger.warning(f"Unknown file type for {name}: {path}; skipping")
                     continue
                 metadata[f"{name}_last_modified"] = Value(string_value=modified_date.isoformat())
             except Exception as e:
@@ -286,7 +285,7 @@ async def write_forecasts_to_data_platform(
     forecasts: dict[str, "xr.DataArray"],
     locations: dict[int, dp.ListLocationsResponseLocationSummary],
     t0: pd.Timestamp,
-    input_s3_paths: dict[str, str],
+    input_paths: dict[str, str],
     app_version: str,
 ) -> None:
     """Build requests and write all model forecasts to the data platform.
@@ -300,7 +299,7 @@ async def write_forecasts_to_data_platform(
         forecasts: Normed national + regional forecasts keyed by model name
         locations: Mapping of GSP ID to location summary, including national (0)
         t0: The forecast init-time, as a naive-UTC timestamp
-        input_s3_paths: Source data S3 paths, keyed by source name, for metadata
+        input_paths: Source data input paths, keyed by source name, for metadata
         app_version: The app version to record against the forecasts
 
     Raises:
@@ -309,7 +308,7 @@ async def write_forecasts_to_data_platform(
     input_metadata = await build_input_metadata(
         client=client,
         location_uuid=locations[0].location_uuid,
-        input_s3_paths=input_s3_paths,
+        input_paths=input_paths,
         app_version=app_version,
     )
 

--- a/src/pvnet_app/forecaster.py
+++ b/src/pvnet_app/forecaster.py
@@ -189,10 +189,10 @@ class PVNetForecaster:
         """Make predictions for the batch."""
         self.logger.debug(f"Predicting for model: {self.model_tag}")
 
-        location_ids = batch["location_id"]
+        location_ids = batch["location_id"].tolist()
         self.logger.debug(f"GSPs: {location_ids}")
 
-        relative_capacities = self.get_relative_capacities(location_ids.tolist())
+        relative_capacities = self.get_relative_capacities(location_ids)
         tensor_batch = copy_batch_to_device(batch_to_tensor(batch), self.device)
 
         # Make regional predictions using the GSP model
@@ -224,7 +224,6 @@ class PVNetForecaster:
             .squeeze(axis=0)  # Remove the batch dimension
         )
 
-        location_ids = batch["location_id"].cpu().numpy().tolist()
         longitudes, latitudes = self.location_coords.loc[
             location_ids, ["longitude", "latitude"]
         ].T.values

--- a/src/pvnet_app/model_input_config.py
+++ b/src/pvnet_app/model_input_config.py
@@ -124,14 +124,14 @@ def get_maximum_satellite_spatial_window_size(data_configs: list[dict]) -> int:
     return max_window_size
 
 
-def get_earliest_satellite_start_interval_minutes(data_configs: list[dict]) -> int:
+def get_earliest_satellite_interval_start_minutes(data_configs: list[dict]) -> int:
     """Return the earliest satellite start interval required by any of the model data configs."""
     # Seed with zero since the start interval must be negative (i.e. in the past) and we want to
     # find the most negative value
     earliest_interval = 0
     for conf in data_configs:
         if "satellite" in conf["input_data"]:
-            start_interval = conf["input_data"]["satellite"]["start_interval_minutes"]
+            start_interval = conf["input_data"]["satellite"]["interval_start_minutes"]
             earliest_interval = min(earliest_interval, start_interval)
     return int(earliest_interval)
 

--- a/src/pvnet_app/model_input_config.py
+++ b/src/pvnet_app/model_input_config.py
@@ -2,6 +2,7 @@
 
 import yaml
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
+import numpy as np
 
 from pvnet_app.consts import (
     generation_path,
@@ -112,6 +113,29 @@ def get_required_nwp_providers(data_configs: list[dict]) -> set[str]:
         for source in conf["input_data"].get("nwp", {}).values():
             providers.add(source["provider"])
     return providers
+
+
+def get_maximum_satellite_spatial_window_size(data_configs: list[dict]) -> int:
+    """Return the maximum satellite spatial window size required by any of the model data configs.
+    """
+    max_window_size = 0
+    for conf in data_configs:
+        if "satellite" in conf["input_data"]:
+            window_size = conf["input_data"]["satellite"]["image_size_pixels_height"]
+            max_window_size = max(max_window_size, window_size)
+    return max_window_size
+
+
+def get_earliest_satellite_start_interval_minutes(data_configs: list[dict]) -> int:
+    """Return the earliest satellite start interval required by any of the model data configs."""
+    # Seed with zero since the start interval must be negative (i.e. in the past) and we want to 
+    # find the most negative value
+    earliest_interval = 0
+    for conf in data_configs:
+        if "satellite" in conf["input_data"]:
+            start_interval = conf["input_data"]["satellite"]["start_interval_minutes"]
+            earliest_interval = min(earliest_interval, start_interval)
+    return int(earliest_interval)
 
 
 def fetch_model_data_config_paths(

--- a/src/pvnet_app/model_input_config.py
+++ b/src/pvnet_app/model_input_config.py
@@ -2,7 +2,6 @@
 
 import yaml
 from pvnet.models.base_model import BaseModel as PVNetBaseModel
-import numpy as np
 
 from pvnet_app.consts import (
     generation_path,
@@ -116,8 +115,7 @@ def get_required_nwp_providers(data_configs: list[dict]) -> set[str]:
 
 
 def get_maximum_satellite_spatial_window_size(data_configs: list[dict]) -> int:
-    """Return the maximum satellite spatial window size required by any of the model data configs.
-    """
+    """Return the max satellite spatial window size required by any of the model data configs."""
     max_window_size = 0
     for conf in data_configs:
         if "satellite" in conf["input_data"]:
@@ -128,7 +126,7 @@ def get_maximum_satellite_spatial_window_size(data_configs: list[dict]) -> int:
 
 def get_earliest_satellite_start_interval_minutes(data_configs: list[dict]) -> int:
     """Return the earliest satellite start interval required by any of the model data configs."""
-    # Seed with zero since the start interval must be negative (i.e. in the past) and we want to 
+    # Seed with zero since the start interval must be negative (i.e. in the past) and we want to
     # find the most negative value
     earliest_interval = 0
     for conf in data_configs:

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -75,6 +75,36 @@ def test_run_sat_15_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp_pat
     assert timesteps_match_expected_freq(dst_path, expected_freq_mins=5)
 
 
+def test_run_sat_too_delayed(
+    sat_5_data_delayed: xr.Dataset,
+    sat_15_data: xr.Dataset,
+    test_t0: pd.Timestamp,
+    tmp_path: Path,
+):
+    """Download and process 5 and 15 minute satellite data where both are extremely delayed
+    """
+
+    dst_path = f"{tmp_path}/sat.zarr"
+
+    with patch(
+        "pvnet_app.data.satellite.open_satellite_data",
+        side_effect=[sat_5_data_delayed, sat_15_data],
+    ):
+        sat_downloader = SatelliteDownloader(
+            t0=test_t0 + pd.Timedelta("12h"),
+            source_path_5="s3://fake/sat5",
+            source_path_15="s3://fake/sat15",
+            s3_region="fake-region",
+            destination_path=dst_path,
+        )
+        sat_downloader.run()
+
+    # If the satellite data is too delayed the valid_times attribute should be None and the
+    # satellite data should not be saved
+    assert sat_downloader.valid_times is None
+    assert not os.path.exists(dst_path)
+
+
 def test_run_sat_delayed_5_and_15_data(
     sat_5_data_delayed: xr.Dataset,
     sat_15_data: xr.Dataset,

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -43,6 +43,8 @@ def test_run_sat_5_data(sat_5_data: xr.Dataset, test_t0: pd.Timestamp, tmp_path:
             source_path_15=None,
             s3_region="fake-region",
             destination_path=dst_path,
+            start_interval_minutes=60,
+            window_size_pixels=24,
         )
         sat_downloader.run()
 
@@ -65,6 +67,8 @@ def test_run_sat_15_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp_pat
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
+            start_interval_minutes=60,
+            window_size_pixels=24,
         )
         sat_downloader.run()
 
@@ -96,6 +100,8 @@ def test_run_sat_too_delayed(
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
+            start_interval_minutes=60,
+            window_size_pixels=24,
         )
         sat_downloader.run()
 
@@ -127,6 +133,8 @@ def test_run_sat_delayed_5_and_15_data(
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
+            start_interval_minutes=60,
+            window_size_pixels=24,
         )
         sat_downloader.run()
 
@@ -153,6 +161,8 @@ def test_run_nan_in_sat_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
+            start_interval_minutes=60,
+            window_size_pixels=24,
         )
         sat_downloader.run()
 

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -85,8 +85,7 @@ def test_run_sat_too_delayed(
     test_t0: pd.Timestamp,
     tmp_path: Path,
 ):
-    """Download and process 5 and 15 minute satellite data where both are extremely delayed
-    """
+    """Download and process 5 and 15 minute satellite data where both are extremely delayed"""
 
     dst_path = f"{tmp_path}/sat.zarr"
 

--- a/tests/data/test_satellite.py
+++ b/tests/data/test_satellite.py
@@ -43,7 +43,7 @@ def test_run_sat_5_data(sat_5_data: xr.Dataset, test_t0: pd.Timestamp, tmp_path:
             source_path_15=None,
             s3_region="fake-region",
             destination_path=dst_path,
-            start_interval_minutes=60,
+            interval_start_minutes=-60,
             window_size_pixels=24,
         )
         sat_downloader.run()
@@ -67,7 +67,7 @@ def test_run_sat_15_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp_pat
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
-            start_interval_minutes=60,
+            interval_start_minutes=-60,
             window_size_pixels=24,
         )
         sat_downloader.run()
@@ -99,7 +99,7 @@ def test_run_sat_too_delayed(
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
-            start_interval_minutes=60,
+            interval_start_minutes=-60,
             window_size_pixels=24,
         )
         sat_downloader.run()
@@ -132,7 +132,7 @@ def test_run_sat_delayed_5_and_15_data(
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
-            start_interval_minutes=60,
+            interval_start_minutes=-60,
             window_size_pixels=24,
         )
         sat_downloader.run()
@@ -160,7 +160,7 @@ def test_run_nan_in_sat_data(sat_15_data: xr.Dataset, test_t0: pd.Timestamp, tmp
             source_path_15="s3://fake/sat15",
             s3_region="fake-region",
             destination_path=dst_path,
-            start_interval_minutes=60,
+            interval_start_minutes=-60,
             window_size_pixels=24,
         )
         sat_downloader.run()


### PR DESCRIPTION
# Pull Request

## Description

This PR includes a few changes
- Update the model table in the README which has gone out of date
- Fix a bug for when the satellite data is too delayed and none is available in the requested time window
- Download the satellite data only for timestamps that the models require
- Remove the hard-coding of 24x24 pixels when checking the area of satellite data fed into PVNet and instead pull the window size from the data config
- Make the metadata construction work on filesystems other than s3

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
