### PR TITLE
Limit parallel writes

### DIFF
--- a/src/pvnet_app/data_platform.py
+++ b/src/pvnet_app/data_platform.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 DATAPLATFORM_MAX_VALUE: float = 1.09
 # Only allow these p-levels to be written to the data-platform
 ALLOWED_PLEVELS: tuple[str, ...] = ("p10", "p50", "p90")
+# Maximum number of concurrent forecast writes to the data-platform
+MAX_INFLIGHT_FORECAST_WRITES: int = 32
 
 
 async def fetch_locations(
@@ -326,11 +328,28 @@ async def write_forecasts_to_data_platform(
         ),
     )
 
+    # Write the forecasts whilst limiting the number of concurrent writes to the data-platform to
+    # avoid overwhelming it
+    semaphore = asyncio.Semaphore(MAX_INFLIGHT_FORECAST_WRITES)
+
     write_results = await asyncio.gather(
-        *(client.create_forecast(req) for reqs in all_requests for req in reqs),
+        *(
+            _create_forecast_bounded(client, req, semaphore)
+            for reqs in all_requests
+            for req in reqs
+        ),
         return_exceptions=True,
     )
 
     errors = [r for r in write_results if isinstance(r, Exception)]
     if errors:
         raise ExceptionGroup("Failed writing forecasts to data platform", errors)
+
+
+async def _create_forecast_bounded(
+    client: dp.DataPlatformDataServiceStub,
+    request: dp.CreateForecastRequest,
+    semaphore: asyncio.Semaphore,
+) -> dp.CreateForecastResponse:
+    async with semaphore:
+        return await client.create_forecast(request)


### PR DESCRIPTION
# Pull Request

## Description

Currently we don't control the number of parallel writes that the app can make at once. With 330 locations and about 6 models we are trying to write around 2000 forecasts to the data-platform. 

I think the number of parallel writes might be limited somewhere below the hood in the tools we are using but I think its better to explicitly limit the number parallel writes in this library.

This is done using the `asyncio.Semaphore` object and I've set a limit of 32 parallel writes. I'll monitor how this impacts the performance of us saving forecasts and might tune value this after this PR if needed


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
