### PR TITLE
Slice datasets to spatial size before saving

### DIFF
--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -35,6 +35,7 @@ from pvnet_app.data_platform import (
 from pvnet_app.forecaster import PVNetForecaster
 from pvnet_app.model_input_config import (
     fetch_model_data_config_paths,
+    get_maximum_nwp_spatial_window_sizes,
     get_maximum_satellite_spatial_window_size,
     get_required_nwp_providers,
     get_required_satellite_interval,
@@ -198,11 +199,13 @@ async def _run_forecast_pipeline(
 
         # Only download the NWP sources which are required by the models
         required_providers = get_required_nwp_providers(data_configs)
+        nwp_window_sizes = get_maximum_nwp_spatial_window_sizes(data_configs)
 
         if "ukv" in required_providers:
             ukv_downloader = UKVDownloader(
                 source_path=settings.nwp_ukv_zarr_path,
                 destination_path=f"{scratch_dir}/{nwp_ukv_path}",
+                window_size_pixels=nwp_window_sizes["ukv"],
             )
             ukv_downloader.run()
 
@@ -212,6 +215,7 @@ async def _run_forecast_pipeline(
             ecmwf_downloader = ECMWFDownloader(
                 source_path=settings.nwp_ecmwf_zarr_path,
                 destination_path=f"{scratch_dir}/{nwp_ecmwf_path}",
+                window_size_pixels=nwp_window_sizes["ecmwf"],
             )
             ecmwf_downloader.run()
 
@@ -221,6 +225,7 @@ async def _run_forecast_pipeline(
             cloudcasting_downloader = CloudcastingDownloader(
                 source_path=settings.cloudcasting_zarr_path,
                 destination_path=f"{scratch_dir}/{nwp_cloudcasting_path}",
+                window_size_pixels=nwp_window_sizes["cloudcasting"],
             )
             cloudcasting_downloader.run()
 

--- a/src/pvnet_app/app.py
+++ b/src/pvnet_app/app.py
@@ -137,7 +137,7 @@ async def _run_forecast_pipeline(
         t0: The forecast init-time. Must be in naive-UTC and floored to 30 minutes
         scratch_dir: Directory for downloaded inputs and temporary files
         write_predictions: If True, write forecasts to the data platform. If
-            False, skip the write and return the forecasters for local testing
+            False, skip the write and return the forecasts for local testing
         device: Device to run the models on
     """
     # ---------------------------------------------------------------------------

--- a/src/pvnet_app/data/gsp.py
+++ b/src/pvnet_app/data/gsp.py
@@ -1,5 +1,6 @@
 """Functions to get GSP data from the data platform."""
 
+from functools import cache
 from importlib.resources import files
 
 import numpy as np
@@ -7,6 +8,7 @@ import pandas as pd
 import xarray as xr
 
 
+@cache
 def get_gsp_locations() -> pd.DataFrame:
     """Load the GSP locations metadata."""
     return pd.read_csv(

--- a/src/pvnet_app/data/nwp.py
+++ b/src/pvnet_app/data/nwp.py
@@ -14,6 +14,8 @@ import xarray as xr
 import xesmf as xe
 from ocf_data_sampler.config.load import load_yaml_configuration
 
+from pvnet_app.data.utils import slice_to_pvnet_spatial_area
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,7 +36,7 @@ def download_data(source: str, destination: str) -> bool:
 
 def regrid_nwp_data(
     ds: xr.Dataset,
-    target_coords_path: str,
+    ds_target_coords: xr.Dataset,
     method: str,
     nwp_source: str,
 ) -> xr.Dataset:
@@ -42,13 +44,10 @@ def regrid_nwp_data(
 
     Args:
         ds: The NWP data to regrid
-        target_coords_path: The path to the target grid
+        ds_target_coords: The target grid dataset
         method: The regridding method to use
         nwp_source: The source of the NWP data (only used for logging messages)
     """
-    # These are the coords we are aiming for
-    ds_target_coords = xr.load_dataset(target_coords_path)
-
     # Check if regridding step needs to be done
     needs_regridding = not (
         ds.latitude.equals(ds_target_coords.latitude)
@@ -59,18 +58,9 @@ def regrid_nwp_data(
         logger.info(f"No regridding required for {nwp_source} - skipping this step")
         return ds
 
-    logger.info(f"Regridding {nwp_source} to expected grid to {target_coords_path}")
+    regridder = xe.Regridder(ds, ds_target_coords, method=method, unmapped_to_nan=True)
 
-    regridder = xe.Regridder(ds, ds_target_coords, method=method)
-
-    # Regrid in a loop to keep RAM usage lower
-    ds_list = []
-    for step in ds.step:
-        # Copy to make sure the data is C-contiguous for efficient regridding
-        ds_step = ds.sel(step=step).copy(deep=True)
-        ds_list.append(regridder(ds_step))
-
-    return xr.concat(ds_list, dim="step")
+    return regridder(ds)
 
 
 def check_model_nwp_inputs_available(
@@ -136,13 +126,19 @@ class NWPDownloader(ABC):
     nwp_source: str
     save_chunk_dict: dict[str, int]
 
-    def __init__(self, source_path: str | None, destination_path: str) -> None:
+    def __init__(
+        self,
+        source_path: str | None,
+        destination_path: str,
+        window_size_pixels: int | None = None,
+    ) -> None:
         """Initialise the NWP downloader."""
         self.source_path = source_path
         self.destination_path = destination_path
         # Initially no valid times are available. This will only change is the data can be
         # downloaded, processed, and saved successfully
         self.valid_times = None
+        self.window_size_pixels = window_size_pixels
 
     @abstractmethod
     def process(self, ds: xr.Dataset) -> xr.Dataset:
@@ -205,17 +201,19 @@ class NWPDownloader(ABC):
             f"{self.nwp_source} has init-time {init_time} and valid times: {valid_times}",
         )
 
-        # Check the data is okay before processing
-        if not self.data_is_okay(ds):
-            logger.warning(f"{self.nwp_source} NWP data did not pass quality checks.")
-            return
-
+        # Process the data to match the training data, then check the quality of the data, and
+        # resave if it passes
         ds = self.process(ds)
-        self.resave(ds)
 
-        # Only store the valid_times if the NWP data has been successfully downloaded,
-        # quality checked, and processed. Else valid_times will be None
-        self.valid_times = valid_times
+        if self.data_is_okay(ds):
+            self.resave(ds)
+
+            # Only store the valid_times if the NWP data has been successfully downloaded,
+            # quality checked, and processed. Else valid_times will be None
+            self.valid_times = valid_times
+
+        else:
+            logger.warning(f"{self.nwp_source} NWP data did not pass quality checks.")
 
     def check_model_inputs_available(
         self,
@@ -248,6 +246,15 @@ class ECMWFDownloader(NWPDownloader):
 
     @override
     def process(self, ds: xr.Dataset) -> xr.Dataset:
+
+        if self.window_size_pixels is not None:
+            # Slice the data to the spatial extent used in PVNet
+            ds = slice_to_pvnet_spatial_area(
+                ds,
+                width_pixels=self.window_size_pixels,
+                height_pixels=self.window_size_pixels,
+            )
+
         return ds
 
 
@@ -261,17 +268,28 @@ class UKVDownloader(NWPDownloader):
         "y_osgb": 100,
     }
 
-    @staticmethod
-    def regrid(ds: xr.Dataset) -> xr.Dataset:
+    def regrid(self, ds: xr.Dataset) -> xr.Dataset:
         """Regrid the UKV data to the target grid.
 
         In production the UKV data is on a different grid structure to the training data. The
-        training data from CEDA is on a regular OSGB grid. The production data is on some other
-        curvilinear grid.
+        training data from CEDA is on a regular OSGB grid. The production data is on a Lambert
+        Azimuthal Equal Area grid
         """
+        ds_target_coords = xr.load_dataset(
+            files("pvnet_app.data").joinpath("nwp_ukv_target_coords.nc")
+        )
+
+        if self.window_size_pixels is not None:
+            # Slice the data to the spatial extent used in PVNet
+            ds_target_coords = slice_to_pvnet_spatial_area(
+                ds_target_coords,
+                width_pixels=self.window_size_pixels,
+                height_pixels=self.window_size_pixels,
+            )
+
         return regrid_nwp_data(
             ds=ds,
-            target_coords_path=files("pvnet_app.data").joinpath("nwp_ukv_target_coords.nc"),
+            ds_target_coords=ds_target_coords,
             method="bilinear",
             nwp_source="UKV",
         )
@@ -325,6 +343,8 @@ class UKVDownloader(NWPDownloader):
     @override
     def process(self, ds: xr.Dataset) -> xr.Dataset:
         ds = self.add_lon_lat_coords(ds)
+        # The regrid step also slices the data to the spatial extent used in PVNet if
+        # self.window_size_pixels is not None
         ds = self.regrid(ds)
         return ds
 
@@ -342,4 +362,12 @@ class CloudcastingDownloader(NWPDownloader):
     @override
     def process(self, ds: xr.Dataset) -> xr.Dataset:
         # The cloudcasting data needs no changes
+        if self.window_size_pixels is not None:
+            # Slice the data to the spatial extent used in PVNet
+            ds = slice_to_pvnet_spatial_area(
+                ds,
+                width_pixels=self.window_size_pixels,
+                height_pixels=self.window_size_pixels,
+            )
+
         return ds

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -403,7 +403,7 @@ class SatelliteDownloader:
         if len(ds.time) == 0:
             logger.warning("No satellite data available in recent window.")
             return
-        
+
         # Slice the data to the spatial extent used in PVNet
         ds = slice_to_pvnet_spatial_area(
             ds,

--- a/src/pvnet_app/data/satellite.py
+++ b/src/pvnet_app/data/satellite.py
@@ -8,12 +8,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from ocf_data_sampler.config.load import load_yaml_configuration
-from ocf_data_sampler.load.utils import make_spatial_coords_increasing
-from ocf_data_sampler.select.geospatial import convert_coordinates
-from ocf_data_sampler.select.location import Location
-from ocf_data_sampler.select.select_spatial_slice import select_spatial_slice_pixels_multiple
 
-from pvnet_app.data.gsp import get_gsp_locations
+from pvnet_app.data.utils import slice_to_pvnet_spatial_area
 
 logger = logging.getLogger(__name__)
 
@@ -253,48 +249,6 @@ def check_model_satellite_inputs_available(
         return available
 
 
-def slice_to_pvnet_satellite_area(
-    ds: xr.Dataset,
-    width_pixels: int,
-    height_pixels: int,
-) -> xr.Dataset:
-    """Get the spatial extent of the satellite data used in PVNet.
-
-    Args:
-        ds: The satellite data
-        width_pixels: The width of the spatial slice in pixels
-        height_pixels: The height of the spatial slice in pixels
-
-    Returns:
-        xr.Dataset: The spatial slice of the dataset used by PVNet
-    """
-    # Cut down the slice for efficiency and reorder the coordinates if needed
-    ds = make_spatial_coords_increasing(
-        ds,
-        x_coord="x_geostationary",
-        y_coord="y_geostationary",
-    )
-
-    # We will loop over all the GSP locations and find the min and max x and y coordinates
-    # This gives us a bounding box used by PVNet
-    df_locs = get_gsp_locations().loc[1:]
-
-    geo_xs, geo_ys = convert_coordinates(
-        x=df_locs.longitude.values,
-        y=df_locs.latitude.values,
-        from_coords="lon_lat",
-        target_coords="geostationary",
-        area_string=str(ds.attrs["area"]),
-    )
-
-    # Add the projection to the locations objects
-    locations = []
-    for x, y, loc_id in zip(geo_xs, geo_ys, df_locs.index.values, strict=True):
-        locations.append(Location(x=x, y=y, coord_system="geostationary", id=loc_id))
-
-    return select_spatial_slice_pixels_multiple(ds, locations, width_pixels, height_pixels)
-
-
 def contains_too_many_of_value(ds: xr.Dataset, value: float, threshold: float) -> bool:
     """Check if the input data contains more than a certain fraction of a given value.
 
@@ -359,13 +313,6 @@ class SatelliteDownloader:
         Returns:
             bool: Whether the data passes the quality checks
         """
-        # Slice the data to the spatial extent used in PVNet
-        ds = slice_to_pvnet_satellite_area(
-            ds,
-            width_pixels=self.window_size_pixels,
-            height_pixels=self.window_size_pixels,
-        )
-
         too_many_nans = contains_too_many_of_value(ds, value=np.nan, threshold=0.05)
 
         return not too_many_nans
@@ -441,8 +388,6 @@ class SatelliteDownloader:
         self.sat_choice = best_source
         logger.info(f"Using {best_source} satellite data")
 
-        # Slice and load into memory for processing
-
         # We slice the data to the required time window for the model, plus a buffer to allow for
         # interpolation of missing timestamps
         start_dt = self.t0 + self.start_interval - MAXIMUM_INTERPOLATION_GAP
@@ -453,12 +398,21 @@ class SatelliteDownloader:
             .sortby("time")
             .drop_duplicates("time", keep="last")
             .sel(time=slice(start_dt, end_dt))
-            .load()
         )
 
         if len(ds.time) == 0:
             logger.warning("No satellite data available in recent window.")
             return
+        
+        # Slice the data to the spatial extent used in PVNet
+        ds = slice_to_pvnet_spatial_area(
+            ds,
+            width_pixels=self.window_size_pixels,
+            height_pixels=self.window_size_pixels,
+        )
+
+        # Load into memory for processing
+        ds = ds.load()
 
         if self.data_is_okay(ds):
             ds = self.process(ds)

--- a/src/pvnet_app/data/utils.py
+++ b/src/pvnet_app/data/utils.py
@@ -1,0 +1,57 @@
+"""Utility functions for processing the raw input data."""
+
+import xarray as xr
+from ocf_data_sampler.load.utils import make_spatial_coords_increasing
+from ocf_data_sampler.select.geospatial import convert_coordinates, find_coord_system
+from ocf_data_sampler.select.location import Location
+from ocf_data_sampler.select.select_spatial_slice import select_spatial_slice_pixels_multiple
+
+from pvnet_app.data.gsp import get_gsp_locations
+
+
+def slice_to_pvnet_spatial_area(
+    ds: xr.Dataset,
+    width_pixels: int,
+    height_pixels: int,
+) -> xr.Dataset:
+    """Get the spatial extent of the satellite data used in PVNet.
+
+    Args:
+        ds: The dataset
+        width_pixels: The width of the spatial slice in pixels
+        height_pixels: The height of the spatial slice in pixels
+
+    Returns:
+        xr.Dataset: The spatial slice of the dataset used by PVNet
+    """
+    coord_system, x_coord, y_coord = find_coord_system(ds)
+
+    # Cut down the slice for efficiency and reorder the coordinates if needed
+    ds = make_spatial_coords_increasing(
+        ds,
+        x_coord=x_coord,
+        y_coord=y_coord,
+    )
+
+    # We will loop over all the GSP locations and find the min and max x and y coordinates
+    # This gives us a bounding box used by PVNet
+    df_locs = get_gsp_locations().loc[1:]
+
+    if coord_system == "lon_lat":
+        xs, ys = df_locs.longitude.values, df_locs.latitude.values
+
+    else:
+        xs, ys = convert_coordinates(
+            x=df_locs.longitude.values,
+            y=df_locs.latitude.values,
+            from_coords="lon_lat",
+            target_coords=coord_system,
+            area_string=str(ds.attrs["area"]) if "area" in ds.attrs else None,
+        )
+
+    # Add the projection to the locations objects
+    locations = []
+    for x, y, loc_id in zip(xs, ys, df_locs.index.values, strict=True):
+        locations.append(Location(x=x, y=y, coord_system=coord_system, id=loc_id))
+
+    return select_spatial_slice_pixels_multiple(ds, locations, width_pixels, height_pixels)

--- a/src/pvnet_app/model_input_config.py
+++ b/src/pvnet_app/model_input_config.py
@@ -132,6 +132,20 @@ def get_maximum_satellite_spatial_window_size(data_configs: list[dict]) -> int:
     return max_window_size
 
 
+def get_maximum_nwp_spatial_window_sizes(data_configs: list[dict]) -> dict[str, int]:
+    """Return the max NWP spatial window sizes required for each source."""
+    max_window_sizes = {}
+    for conf in data_configs:
+        if "nwp" in conf["input_data"]:
+            for source_name, source in conf["input_data"]["nwp"].items():
+                window_size = source["image_size_pixels_height"]
+                if source_name not in max_window_sizes:
+                    max_window_sizes[source_name] = window_size
+                else:
+                    max_window_sizes[source_name] = max(max_window_sizes[source_name], window_size)
+    return max_window_sizes
+
+
 def get_required_satellite_interval(data_configs: list[dict]) -> tuple[int, int]:
     """Return the minimum satellite interval required to cover all intervals in the data configs."""
     min_start_interval = float("inf")

--- a/tests/data/test_nwp.py
+++ b/tests/data/test_nwp.py
@@ -58,12 +58,14 @@ def test_check_model_nwp_inputs_available(
     ukv_downloader = UKVDownloader(
         source_path=source_ukv_path,
         destination_path=f"{tmp_path}/ukv.zarr",
+        window_size_pixels=2,
     )
     ukv_downloader.run()
 
     ecmwf_downloader = ECMWFDownloader(
         source_path=source_ecmwf_path,
         destination_path=f"{tmp_path}/ecmwf.zarr",
+        window_size_pixels=2,
     )
     ecmwf_downloader.run()
 
@@ -75,12 +77,14 @@ def test_check_model_nwp_inputs_available(
     ukv_downloader = UKVDownloader(
         source_path="empty_ukv_path.zarr",
         destination_path="dummy.zarr",
+        window_size_pixels=2,
     )
     ukv_downloader.run()
 
     ecmwf_downloader = ECMWFDownloader(
         source_path="empty_ecmwf_path.zarr",
         destination_path="dummy.zarr",
+        window_size_pixels=2,
     )
     ecmwf_downloader.run()
 
@@ -100,12 +104,14 @@ def test_check_model_nwp_inputs_available(
     ukv_downloader = UKVDownloader(
         source_path=source_ukv_path,
         destination_path=f"{tmp_path}/short_ukv.zarr",
+        window_size_pixels=2,
     )
     ukv_downloader.run()
 
     ecmwf_downloader = ECMWFDownloader(
         source_path=source_ecmwf_path,
         destination_path=f"{tmp_path}/short_ecmwf.zarr",
+        window_size_pixels=2,
     )
     ecmwf_downloader.run()
 


### PR DESCRIPTION
# Pull Request

## Description

Spatially slice the input satellite and NWP datasets before saving. Doing this slice means we save less to disk and also means we can do more targeted quality control covering only the area the model is actually going to see

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
