### PR TITLE
Split image layers for faster pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 
 # --- Use conda to install required binaries into venv --- #
 FROM quay.io/condaforge/miniforge3:latest AS build-venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # --- Use conda to install required binaries into venv --- #
 FROM quay.io/condaforge/miniforge3:latest AS build-venv
 
@@ -31,8 +33,29 @@ RUN uv sync --no-editable --no-dev --compile-bytecode --inexact
 # --- Runtime image --- #
 FROM python:3.12-slim
 
-# Copy required elements of the builder image
-COPY --from=build-app /app/.venv /app/.venv
+# Copy the venv in multiple layers so the largest binary dependencies can be pulled separately.
+COPY --from=build-app \
+    --exclude=lib/python3.12/site-packages/torch \
+    --exclude=lib/python3.12/site-packages/torch/** \
+    --exclude=lib/python3.12/site-packages/llvmlite \
+    --exclude=lib/python3.12/site-packages/llvmlite/** \
+    --exclude=lib/python3.12/site-packages/scipy \
+    --exclude=lib/python3.12/site-packages/scipy/** \
+    --exclude=lib/python3.12/site-packages/scipy.libs \
+    --exclude=lib/python3.12/site-packages/scipy.libs/** \
+    /app/.venv /app/.venv
+COPY --from=build-app \
+    /app/.venv/lib/python3.12/site-packages/llvmlite \
+    /app/.venv/lib/python3.12/site-packages/llvmlite
+COPY --from=build-app \
+    /app/.venv/lib/python3.12/site-packages/scipy \
+    /app/.venv/lib/python3.12/site-packages/scipy
+COPY --from=build-app \
+    /app/.venv/lib/python3.12/site-packages/scipy.libs \
+    /app/.venv/lib/python3.12/site-packages/scipy.libs
+COPY --from=build-app \
+    /app/.venv/lib/python3.12/site-packages/torch \
+    /app/.venv/lib/python3.12/site-packages/torch
 
 # This is just a check to make sure it works, we've had problems with this in the past
 ENV PATH="/app/.venv/bin:${PATH}"


### PR DESCRIPTION
# Pull Request

## Description

The image currently has one large layer. If it's split into multiple layers it is possible to pull those concurrently and so have a faster cold start of the app. I want to try this

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
